### PR TITLE
Fix buildfarm failures on Ubuntu Resolute

### DIFF
--- a/cuda_buffer_backend/cuda_buffer/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer/CMakeLists.txt
@@ -14,6 +14,25 @@ find_package(rosidl_buffer REQUIRED)
 find_package(cuda_buffer_backend_msgs REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rcutils REQUIRED)
+
+# Workaround for CMake's FindCUDAToolkit: on Ubuntu's split nvidia-cuda-dev
+# layout (headers in /usr/include, libs in /usr/lib/<multiarch>) it derives
+# the include path as /usr/lib/include and fails. Pre-populate the cache
+# variable that find_path() inside FindCUDAToolkit would otherwise compute,
+# so the broken auto-detection is skipped.
+# Refs https://gitlab.kitware.com/cmake/cmake/-/issues/24856
+find_path(_CUDA_RUNTIME_DIR
+  NAMES cuda_runtime.h
+  HINTS
+    ENV CUDA_HOME
+    ENV CUDA_PATH
+    /usr/local/cuda/include
+    /usr/include
+)
+if(_CUDA_RUNTIME_DIR AND NOT DEFINED CUDAToolkit_INCLUDE_DIRECTORIES)
+  set(CUDAToolkit_INCLUDE_DIRECTORIES "${_CUDA_RUNTIME_DIR}" CACHE PATH
+    "CUDA include dir (FindCUDAToolkit nvidia-cuda-dev workaround)")
+endif()
 find_package(CUDAToolkit REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED

--- a/cuda_buffer_backend/cuda_buffer/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer/CMakeLists.txt
@@ -15,12 +15,10 @@ find_package(cuda_buffer_backend_msgs REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rcutils REQUIRED)
 
-# Workaround for CMake's FindCUDAToolkit: on Ubuntu's split nvidia-cuda-dev
-# layout (headers in /usr/include, libs in /usr/lib/<multiarch>) it derives
-# the include path as /usr/lib/include and fails. Pre-populate the cache
-# variable that find_path() inside FindCUDAToolkit would otherwise compute,
-# so the broken auto-detection is skipped.
-# Refs https://gitlab.kitware.com/cmake/cmake/-/issues/24856
+# Workaround for CMake's FindCUDAToolkit on Ubuntu's split nvidia-cuda-dev
+# layout in the bloom build pipeline. Pre-populate the cache variable to
+# skip the broken auto-detection.
+# Related: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995122
 find_path(_CUDA_RUNTIME_DIR
   NAMES cuda_runtime.h
   HINTS

--- a/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
@@ -11,6 +11,25 @@ endif()
 
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
+
+# Workaround for CMake's FindCUDAToolkit: on Ubuntu's split nvidia-cuda-dev
+# layout (headers in /usr/include, libs in /usr/lib/<multiarch>) it derives
+# the include path as /usr/lib/include and fails. Pre-populate the cache
+# variable that find_path() inside FindCUDAToolkit would otherwise compute,
+# so the broken auto-detection is skipped.
+# Refs https://gitlab.kitware.com/cmake/cmake/-/issues/24856
+find_path(_CUDA_RUNTIME_DIR
+  NAMES cuda_runtime.h
+  HINTS
+    ENV CUDA_HOME
+    ENV CUDA_PATH
+    /usr/local/cuda/include
+    /usr/include
+)
+if(_CUDA_RUNTIME_DIR AND NOT DEFINED CUDAToolkit_INCLUDE_DIRECTORIES)
+  set(CUDAToolkit_INCLUDE_DIRECTORIES "${_CUDA_RUNTIME_DIR}" CACHE PATH
+    "CUDA include dir (FindCUDAToolkit nvidia-cuda-dev workaround)")
+endif()
 find_package(CUDAToolkit REQUIRED)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED

--- a/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
@@ -12,12 +12,10 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-# Workaround for CMake's FindCUDAToolkit: on Ubuntu's split nvidia-cuda-dev
-# layout (headers in /usr/include, libs in /usr/lib/<multiarch>) it derives
-# the include path as /usr/lib/include and fails. Pre-populate the cache
-# variable that find_path() inside FindCUDAToolkit would otherwise compute,
-# so the broken auto-detection is skipped.
-# Refs https://gitlab.kitware.com/cmake/cmake/-/issues/24856
+# Workaround for CMake's FindCUDAToolkit on Ubuntu's split nvidia-cuda-dev
+# layout in the bloom build pipeline. Pre-populate the cache variable to
+# skip the broken auto-detection.
+# Related: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995122
 find_path(_CUDA_RUNTIME_DIR
   NAMES cuda_runtime.h
   HINTS

--- a/libtorch_vendor/CMakeLists.txt
+++ b/libtorch_vendor/CMakeLists.txt
@@ -91,6 +91,27 @@ if(NOT Torch_FOUND OR FORCE_BUILD_VENDOR_PKG)
     USE_SOURCE_PERMISSIONS
   )
 
+  # Pre-strip the prebuilt PyTorch shared libraries. PyTorch's libtorch_cpu.so
+  # ships with ELF features (very large section table, debug-section flags)
+  # that newer binutils' objcopy cannot round-trip cleanly, which makes
+  # dh_strip's "objcopy --only-keep-debug" fail with messages like:
+  #   readelf: Error: no .dynamic section in the dynamic segment
+  #   objcopy: ... has a corrupt string table index
+  # Stripping debug+unneeded symbols here normalizes the ELF so dh_strip
+  # finishes cleanly when the debs are produced on the buildfarm.
+  install(CODE "
+    file(GLOB_RECURSE _libtorch_sos
+      \"\${CMAKE_INSTALL_PREFIX}/opt/${PROJECT_NAME}/lib/*.so\"
+      \"\${CMAKE_INSTALL_PREFIX}/opt/${PROJECT_NAME}/lib/*.so.*\")
+    foreach(_so IN LISTS _libtorch_sos)
+      if(NOT IS_SYMLINK \"\${_so}\")
+        execute_process(
+          COMMAND strip --strip-unneeded \"\${_so}\"
+          OUTPUT_QUIET ERROR_QUIET)
+      endif()
+    endforeach()
+  ")
+
   ament_index_register_resource("vendor_packages" CONTENT "opt/${PROJECT_NAME}")
 
   # Install environment hooks so downstream binaries can locate the vendored

--- a/libtorch_vendor/CMakeLists.txt
+++ b/libtorch_vendor/CMakeLists.txt
@@ -91,25 +91,15 @@ if(NOT Torch_FOUND OR FORCE_BUILD_VENDOR_PKG)
     USE_SOURCE_PERMISSIONS
   )
 
-  # Pre-strip the prebuilt PyTorch shared libraries. PyTorch's libtorch_cpu.so
-  # ships with ELF features (very large section table, debug-section flags)
-  # that newer binutils' objcopy cannot round-trip cleanly, which makes
-  # dh_strip's "objcopy --only-keep-debug" fail with messages like:
-  #   readelf: Error: no .dynamic section in the dynamic segment
-  #   objcopy: ... has a corrupt string table index
-  # Stripping debug+unneeded symbols here normalizes the ELF so dh_strip
-  # finishes cleanly when the debs are produced on the buildfarm.
+  # Pre-strip libtorch_cpu.so so dh_strip's objcopy doesn't fail on its
+  # non-standard ELF section table on the buildfarm.
   install(CODE "
-    file(GLOB_RECURSE _libtorch_sos
-      \"\${CMAKE_INSTALL_PREFIX}/opt/${PROJECT_NAME}/lib/*.so\"
-      \"\${CMAKE_INSTALL_PREFIX}/opt/${PROJECT_NAME}/lib/*.so.*\")
-    foreach(_so IN LISTS _libtorch_sos)
-      if(NOT IS_SYMLINK \"\${_so}\")
-        execute_process(
-          COMMAND strip --strip-unneeded \"\${_so}\"
-          OUTPUT_QUIET ERROR_QUIET)
-      endif()
-    endforeach()
+    set(_lt \"\${CMAKE_INSTALL_PREFIX}/opt/${PROJECT_NAME}/lib/libtorch_cpu.so\")
+    if(EXISTS \"\${_lt}\" AND NOT IS_SYMLINK \"\${_lt}\")
+      execute_process(
+        COMMAND strip --strip-unneeded \"\${_lt}\"
+        OUTPUT_QUIET ERROR_QUIET)
+    endif()
   ")
 
   ament_index_register_resource("vendor_packages" CONTENT "opt/${PROJECT_NAME}")


### PR DESCRIPTION
## Description

Fixes the buildfarm failures on Ubuntu Resolute (26.04) seen in https://build.ros2.org/view/Rdev/job/Rdev__rosidl_buffer_backends__ubuntu_resolute_amd64/2/console.

Two independent issues are addressed:

**1. `cuda_buffer` / `cuda_buffer_backend` fail to configure**

```
-- Unable to find cuda_runtime.h in "/usr/lib/include" for CUDAToolkit_INCLUDE_DIRECTORIES.
CMake Error: Could NOT find CUDAToolkit (missing: CUDAToolkit_INCLUDE_DIRECTORIES) (found version "12.4.131")
```

CMake's `FindCUDAToolkit` walks up from `libcudart.so` to derive the toolkit root, then looks for `cuda_runtime.h` under `<root>/include`. On Ubuntu's split `nvidia-cuda-dev` layout (headers in `/usr/include`, libs in `/usr/lib/<multiarch>`), and with the flag set passed by `dh_auto_configure` on the build farm, the heuristic walks up only one level and ends up looking in `/usr/lib/include`, which doesn't exist. Refs https://gitlab.kitware.com/cmake/cmake/-/issues/24856.

The fix discovers `cuda_runtime.h` with a small guarded `find_path` and pre-populates `CUDAToolkit_INCLUDE_DIRECTORIES` so `FindCUDAToolkit`'s broken auto-detection is skipped. No-op on systems where the header isn't found by the search.

**2. `libtorch_vendor` fails in `dh_strip`**

```
readelf: Error: no .dynamic section in the dynamic segment
objcopy: ...libtorch_cpu.so has a corrupt string table index
dh_strip: error: objcopy --only-keep-debug ... returned exit code 1
```

PyTorch's `libtorch_cpu.so` ships with ELF features that newer `binutils`' `objcopy` can't round-trip cleanly, breaking `dh_strip`'s debug-symbol extraction step on the build farm. The fix pre-strips the vendored `.so` files in `install(CODE …)` so `dh_strip` later sees a clean ELF.

Fixes # (issue)

### Did you use Generative AI?

Yes. Claude via Cursor was used to assist with diagnosing the build farm failures and authoring the workarounds.

### Additional Information

The CUDA hint is a workaround for a CMake-side bug (issue 24856 above); it should be removable once `FindCUDAToolkit` handles the Debian/Ubuntu split layout natively.
