### PR TITLE
Add tegra support

### DIFF
--- a/cuda_buffer_backend/cuda_buffer_backend/src/cuda_buffer_backend_plugin.cpp
+++ b/cuda_buffer_backend/cuda_buffer_backend/src/cuda_buffer_backend_plugin.cpp
@@ -292,18 +292,8 @@ std::unique_ptr<void, void (*)(void *)> CudaBufferBackend::from_descriptor_with_
     }
   }
 
-  if (!descriptor->serialized_data.empty()) {
-    auto result = std::make_unique<CudaBufferImpl<uint8_t>>(descriptor->size);
-    size_t copy_size = std::min(descriptor->serialized_data.size(), byte_size);
-    CUDA_CHECK(cudaMemcpy(result->get_cuda_buffer().get_device_ptr(),
-        descriptor->serialized_data.data(), copy_size, cudaMemcpyHostToDevice));
-    return {result.release(), [](void * p) {
-        delete static_cast<rosidl::BufferImplBase<uint8_t> *>(p);
-      }};
-  }
-
   RCUTILS_LOG_WARN_NAMED("cuda_buffer_backend",
-    "Dropping stale descriptor: IPC failed and no serialized_data available");
+    "Dropping stale descriptor: IPC failed");
   auto empty = std::make_unique<CudaBufferImpl<uint8_t>>();
   return {empty.release(), [](void * p) {
       delete static_cast<rosidl::BufferImplBase<uint8_t> *>(p);

--- a/cuda_buffer_backend/cuda_buffer_backend_msgs/msg/CudaBufferDescriptor.msg
+++ b/cuda_buffer_backend/cuda_buffer_backend_msgs/msg/CudaBufferDescriptor.msg
@@ -26,6 +26,3 @@ uint64 ipc_uid                 # Unique ID per publish for staleness detection
 
 # CUDA IPC event for inter-process GPU synchronization
 uint8[64] ipc_event_handle     # cudaIpcEventHandle_t (64 bytes)
-
-# CPU fallback data (empty when IPC is used)
-uint8[] serialized_data

--- a/libtorch_vendor/CMakeLists.txt
+++ b/libtorch_vendor/CMakeLists.txt
@@ -10,11 +10,7 @@ find_package(ament_cmake_vendor_package REQUIRED)
 set(LIBTORCH_VERSION "" CACHE STRING
   "LibTorch version to download. Auto-selected per CUDA variant if empty.")
 set(LIBTORCH_CUDA_VERSION "" CACHE STRING
-  "CUDA variant override (cu118, cu121, cu124, cu126, cu128, cu129, cu130, cpu). Auto-detected if empty.")
-set(LIBTORCH_URL "" CACHE STRING
-  "Explicit LibTorch or PyTorch wheel archive URL.")
-set(LIBTORCH_ARCHIVE_LAYOUT "" CACHE STRING
-  "Archive layout override: libtorch or torch_wheel. Auto-detected if empty.")
+  "CUDA variant override (cu118, cu121, cu124, cu126, cu128, cu129, cpu). Auto-detected if empty.")
 
 option(FORCE_BUILD_VENDOR_PKG
   "Build vendor packages from source, even if system-installed packages are available"
@@ -118,40 +114,20 @@ else()
     message(STATUS "${PROJECT_NAME}: forcing vendor build (FORCE_BUILD_VENDOR_PKG)")
   endif()
 
-  if(LIBTORCH_URL STREQUAL "")
-    # Starting with LibTorch 2.8.0, PyTorch dropped the "-cxx11-abi-" infix from
-    # the Linux archive name (they no longer ship the pre-cxx11-abi variant).
-    if(LIBTORCH_VERSION VERSION_GREATER_EQUAL "2.8.0")
-      set(_archive_prefix "libtorch-shared-with-deps")
-    else()
-      set(_archive_prefix "libtorch-cxx11-abi-shared-with-deps")
-    endif()
-    string(CONCAT _url
-      "https://download.pytorch.org/libtorch/${LIBTORCH_CUDA_VERSION}/"
-      "${_archive_prefix}-${LIBTORCH_VERSION}%2B${LIBTORCH_CUDA_VERSION}.zip")
+  # Starting with LibTorch 2.8.0, PyTorch dropped the "-cxx11-abi-" infix from
+  # the Linux archive name (they no longer ship the pre-cxx11-abi variant).
+  if(LIBTORCH_VERSION VERSION_GREATER_EQUAL "2.8.0")
+    set(_archive_prefix "libtorch-shared-with-deps")
   else()
-    set(_url "${LIBTORCH_URL}")
+    set(_archive_prefix "libtorch-cxx11-abi-shared-with-deps")
   endif()
-
-  if(LIBTORCH_ARCHIVE_LAYOUT STREQUAL "")
-    if(_url MATCHES "\\.whl($|[?#])")
-      set(LIBTORCH_ARCHIVE_LAYOUT "torch_wheel")
-    else()
-      set(LIBTORCH_ARCHIVE_LAYOUT "libtorch")
-    endif()
-  endif()
+  string(CONCAT _url
+    "https://download.pytorch.org/libtorch/${LIBTORCH_CUDA_VERSION}/"
+    "${_archive_prefix}-${LIBTORCH_VERSION}%2B${LIBTORCH_CUDA_VERSION}.zip")
 
   set(_archive "${CMAKE_CURRENT_BINARY_DIR}/libtorch_archive")
   set(_extract_dir "${CMAKE_CURRENT_BINARY_DIR}/libtorch_extracted")
-
-  if(LIBTORCH_ARCHIVE_LAYOUT STREQUAL "torch_wheel")
-    set(_torch_root "${_extract_dir}/torch")
-  elseif(LIBTORCH_ARCHIVE_LAYOUT STREQUAL "libtorch")
-    set(_torch_root "${_extract_dir}/libtorch")
-  else()
-    message(FATAL_ERROR
-      "${PROJECT_NAME}: unsupported LIBTORCH_ARCHIVE_LAYOUT '${LIBTORCH_ARCHIVE_LAYOUT}'")
-  endif()
+  set(_torch_root "${_extract_dir}/libtorch")
 
   if(NOT EXISTS "${_torch_root}/share/cmake/Torch/TorchConfig.cmake")
     message(STATUS "${PROJECT_NAME}: downloading LibTorch ${LIBTORCH_VERSION}+${LIBTORCH_CUDA_VERSION}")

--- a/libtorch_vendor/CMakeLists.txt
+++ b/libtorch_vendor/CMakeLists.txt
@@ -10,17 +10,15 @@ find_package(ament_cmake_vendor_package REQUIRED)
 set(LIBTORCH_VERSION "" CACHE STRING
   "LibTorch version to download. Auto-selected per CUDA variant if empty.")
 set(LIBTORCH_CUDA_VERSION "" CACHE STRING
-  "CUDA variant override (cu118, cu121, cu124, cu126, cu128, cu129, cpu). Auto-detected if empty.")
+  "CUDA variant override (cu118, cu121, cu124, cu126, cu128, cu129, cu130, cpu). Auto-detected if empty.")
+set(LIBTORCH_URL "" CACHE STRING
+  "Explicit LibTorch or PyTorch wheel archive URL.")
+set(LIBTORCH_ARCHIVE_LAYOUT "" CACHE STRING
+  "Archive layout override: libtorch or torch_wheel. Auto-detected if empty.")
 
 option(FORCE_BUILD_VENDOR_PKG
   "Build vendor packages from source, even if system-installed packages are available"
   OFF)
-
-string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _processor)
-set(_is_aarch64 FALSE)
-if(_processor MATCHES "^(aarch64|arm64)$")
-  set(_is_aarch64 TRUE)
-endif()
 
 if(LIBTORCH_CUDA_VERSION STREQUAL "")
   find_package(CUDAToolkit QUIET)
@@ -57,53 +55,105 @@ if(LIBTORCH_VERSION STREQUAL "")
   endif()
 endif()
 
-find_package(Torch QUIET)
-
-# On aarch64 (Jetson), PyTorch ships with JetPack as a Python package; auto-locate
-# its CMake config so find_package(Torch) succeeds without manual CMAKE_PREFIX_PATH.
-if(NOT Torch_FOUND AND _is_aarch64)
+# Provide a non-empty CMAKE_CUDA_ARCHITECTURES (required by CMake 3.28+
+# when find_package(Torch) calls enable_language(CUDA)).
+if(NOT CMAKE_CUDA_ARCHITECTURES)
   execute_process(
-    COMMAND python3 -c "import torch; print(torch.utils.cmake_prefix_path)"
-    OUTPUT_VARIABLE _torch_python_cmake_prefix
+    COMMAND python3 -c "import torch; print(';'.join(a.split('_',1)[-1] for a in torch.cuda.get_arch_list()))"
+    OUTPUT_VARIABLE _torch_arch_list
     OUTPUT_STRIP_TRAILING_WHITESPACE
-    RESULT_VARIABLE _torch_python_rc
+    RESULT_VARIABLE _torch_arch_rc
     ERROR_QUIET
   )
-  if(_torch_python_rc EQUAL 0 AND IS_DIRECTORY "${_torch_python_cmake_prefix}")
-    list(APPEND CMAKE_PREFIX_PATH "${_torch_python_cmake_prefix}")
-    find_package(Torch QUIET)
+  if(_torch_arch_rc EQUAL 0 AND _torch_arch_list)
+    set(CMAKE_CUDA_ARCHITECTURES "${_torch_arch_list}" CACHE STRING
+      "CUDA archs (auto-detected by libtorch_vendor)" FORCE)
+  else()
+    set(CMAKE_CUDA_ARCHITECTURES "75" CACHE STRING
+      "CUDA archs (libtorch_vendor fallback, satisfies CMake validation)" FORCE)
   endif()
 endif()
 
-if(NOT Torch_FOUND OR FORCE_BUILD_VENDOR_PKG)
+# PyTorch only publishes pre-built LibTorch archives for x86_64
+# On aarch64 (e.g. NVIDIA Jetson) LibTorch ships within Jetpack,
+# so the platform-provided installation must be reused.
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _system_arch)
+if(_system_arch MATCHES "aarch64|arm64")
+  set(_is_aarch64 TRUE)
+else()
+  set(_is_aarch64 FALSE)
+endif()
+
+# Help find_package(Torch) locate a pip/system-installed LibTorch. This enables
+# "reuse if present" on x86_64 and is the primary discovery path on aarch64.
+if(NOT Torch_DIR)
+  execute_process(
+    COMMAND python3 -c "import torch, os; print(os.path.join(os.path.dirname(torch.__file__), 'share', 'cmake', 'Torch'))"
+    OUTPUT_VARIABLE _py_torch_dir
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _py_torch_rc
+    ERROR_QUIET
+  )
+  if(_py_torch_rc EQUAL 0 AND EXISTS "${_py_torch_dir}/TorchConfig.cmake")
+    set(Torch_DIR "${_py_torch_dir}")
+    message(STATUS "${PROJECT_NAME}: discovered LibTorch via python3 at ${Torch_DIR}")
+  endif()
+endif()
+
+find_package(Torch QUIET)
+
+if(Torch_FOUND AND NOT FORCE_BUILD_VENDOR_PKG)
+  message(STATUS "${PROJECT_NAME}: system LibTorch ${Torch_VERSION} found, skipping download")
+  set(LIBTORCH_VENDOR_TORCH_DIR "${Torch_DIR}" CACHE PATH
+    "Torch_DIR found by libtorch_vendor")
+elseif(_is_aarch64)
+  message(FATAL_ERROR
+    "${PROJECT_NAME}: no pre-built LibTorch archive is published for aarch64. "
+    "On NVIDIA Jetson, LibTorch ships within JetPack, so the platform-provided "
+    "installation must be reused. Ensure the JetPack PyTorch is installed so that "
+    "'python3 -c \"import torch\"' or find_package(Torch) can locate it, then "
+    "rebuild. Set Torch_DIR explicitly if it lives in a non-standard location.")
+else()
   if(Torch_FOUND)
     message(STATUS "${PROJECT_NAME}: forcing vendor build (FORCE_BUILD_VENDOR_PKG)")
   endif()
 
-  if(_is_aarch64)
-    # PyTorch's official libtorch is x86_64 only, so we can't download a
-    # Jetson build. Either Torch was found above (JetPack), or the user
-    # needs to install it.
-    message(FATAL_ERROR
-      "${PROJECT_NAME}: PyTorch not found on aarch64. Install JetPack "
-      "(which provides PyTorch) on the target.")
+  if(LIBTORCH_URL STREQUAL "")
+    # Starting with LibTorch 2.8.0, PyTorch dropped the "-cxx11-abi-" infix from
+    # the Linux archive name (they no longer ship the pre-cxx11-abi variant).
+    if(LIBTORCH_VERSION VERSION_GREATER_EQUAL "2.8.0")
+      set(_archive_prefix "libtorch-shared-with-deps")
+    else()
+      set(_archive_prefix "libtorch-cxx11-abi-shared-with-deps")
+    endif()
+    string(CONCAT _url
+      "https://download.pytorch.org/libtorch/${LIBTORCH_CUDA_VERSION}/"
+      "${_archive_prefix}-${LIBTORCH_VERSION}%2B${LIBTORCH_CUDA_VERSION}.zip")
+  else()
+    set(_url "${LIBTORCH_URL}")
   endif()
 
-  # x86_64: PyTorch's official libtorch zip (extracts into a "libtorch/" subdir).
-  # Starting with LibTorch 2.8.0, PyTorch dropped the "-cxx11-abi-" infix from
-  # the Linux archive name (they no longer ship the pre-cxx11-abi variant).
-  if(LIBTORCH_VERSION VERSION_GREATER_EQUAL "2.8.0")
-    set(_archive_prefix "libtorch-shared-with-deps")
-  else()
-    set(_archive_prefix "libtorch-cxx11-abi-shared-with-deps")
+  if(LIBTORCH_ARCHIVE_LAYOUT STREQUAL "")
+    if(_url MATCHES "\\.whl($|[?#])")
+      set(LIBTORCH_ARCHIVE_LAYOUT "torch_wheel")
+    else()
+      set(LIBTORCH_ARCHIVE_LAYOUT "libtorch")
+    endif()
   endif()
-  string(CONCAT _url
-    "https://download.pytorch.org/libtorch/${LIBTORCH_CUDA_VERSION}/"
-    "${_archive_prefix}-${LIBTORCH_VERSION}%2B${LIBTORCH_CUDA_VERSION}.zip")
-  set(_archive "${CMAKE_CURRENT_BINARY_DIR}/libtorch.zip")
+
+  set(_archive "${CMAKE_CURRENT_BINARY_DIR}/libtorch_archive")
   set(_extract_dir "${CMAKE_CURRENT_BINARY_DIR}/libtorch_extracted")
 
-  if(NOT EXISTS "${_extract_dir}/libtorch/share/cmake/Torch/TorchConfig.cmake")
+  if(LIBTORCH_ARCHIVE_LAYOUT STREQUAL "torch_wheel")
+    set(_torch_root "${_extract_dir}/torch")
+  elseif(LIBTORCH_ARCHIVE_LAYOUT STREQUAL "libtorch")
+    set(_torch_root "${_extract_dir}/libtorch")
+  else()
+    message(FATAL_ERROR
+      "${PROJECT_NAME}: unsupported LIBTORCH_ARCHIVE_LAYOUT '${LIBTORCH_ARCHIVE_LAYOUT}'")
+  endif()
+
+  if(NOT EXISTS "${_torch_root}/share/cmake/Torch/TorchConfig.cmake")
     message(STATUS "${PROJECT_NAME}: downloading LibTorch ${LIBTORCH_VERSION}+${LIBTORCH_CUDA_VERSION}")
     message(STATUS "${PROJECT_NAME}: URL: ${_url}")
     file(DOWNLOAD "${_url}" "${_archive}" SHOW_PROGRESS STATUS _dl_status)
@@ -115,10 +165,10 @@ if(NOT Torch_FOUND OR FORCE_BUILD_VENDOR_PKG)
     file(ARCHIVE_EXTRACT INPUT "${_archive}" DESTINATION "${_extract_dir}")
     file(REMOVE "${_archive}")
   else()
-    message(STATUS "${PROJECT_NAME}: using cached LibTorch at ${_extract_dir}")
+    message(STATUS "${PROJECT_NAME}: using cached LibTorch at ${_torch_root}")
   endif()
 
-  install(DIRECTORY "${_extract_dir}/libtorch/"
+  install(DIRECTORY "${_torch_root}/"
     DESTINATION "opt/${PROJECT_NAME}"
     USE_SOURCE_PERMISSIONS
   )
@@ -149,8 +199,6 @@ if(NOT Torch_FOUND OR FORCE_BUILD_VENDOR_PKG)
     "${ament_cmake_vendor_package_DIR}/templates/vendor_package.sh.in"
     "${ament_cmake_vendor_package_DIR}/templates/vendor_package.dsv.in"
   )
-else()
-  message(STATUS "${PROJECT_NAME}: system LibTorch ${Torch_VERSION} found, skipping download")
 endif()
 
 if(BUILD_TESTING)
@@ -161,3 +209,4 @@ endif()
 ament_package(
   CONFIG_EXTRAS_POST "libtorch_vendor-extras.cmake.in"
 )
+

--- a/libtorch_vendor/CMakeLists.txt
+++ b/libtorch_vendor/CMakeLists.txt
@@ -16,6 +16,12 @@ option(FORCE_BUILD_VENDOR_PKG
   "Build vendor packages from source, even if system-installed packages are available"
   OFF)
 
+string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _processor)
+set(_is_aarch64 FALSE)
+if(_processor MATCHES "^(aarch64|arm64)$")
+  set(_is_aarch64 TRUE)
+endif()
+
 if(LIBTORCH_CUDA_VERSION STREQUAL "")
   find_package(CUDAToolkit QUIET)
   if(CUDAToolkit_FOUND)
@@ -53,11 +59,37 @@ endif()
 
 find_package(Torch QUIET)
 
+# On aarch64 (Jetson), PyTorch ships with JetPack as a Python package; auto-locate
+# its CMake config so find_package(Torch) succeeds without manual CMAKE_PREFIX_PATH.
+if(NOT Torch_FOUND AND _is_aarch64)
+  execute_process(
+    COMMAND python3 -c "import torch; print(torch.utils.cmake_prefix_path)"
+    OUTPUT_VARIABLE _torch_python_cmake_prefix
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _torch_python_rc
+    ERROR_QUIET
+  )
+  if(_torch_python_rc EQUAL 0 AND IS_DIRECTORY "${_torch_python_cmake_prefix}")
+    list(APPEND CMAKE_PREFIX_PATH "${_torch_python_cmake_prefix}")
+    find_package(Torch QUIET)
+  endif()
+endif()
+
 if(NOT Torch_FOUND OR FORCE_BUILD_VENDOR_PKG)
   if(Torch_FOUND)
     message(STATUS "${PROJECT_NAME}: forcing vendor build (FORCE_BUILD_VENDOR_PKG)")
   endif()
 
+  if(_is_aarch64)
+    # PyTorch's official libtorch is x86_64 only, so we can't download a
+    # Jetson build. Either Torch was found above (JetPack), or the user
+    # needs to install it.
+    message(FATAL_ERROR
+      "${PROJECT_NAME}: PyTorch not found on aarch64. Install JetPack "
+      "(which provides PyTorch) on the target.")
+  endif()
+
+  # x86_64: PyTorch's official libtorch zip (extracts into a "libtorch/" subdir).
   # Starting with LibTorch 2.8.0, PyTorch dropped the "-cxx11-abi-" infix from
   # the Linux archive name (they no longer ship the pre-cxx11-abi variant).
   if(LIBTORCH_VERSION VERSION_GREATER_EQUAL "2.8.0")
@@ -94,7 +126,7 @@ if(NOT Torch_FOUND OR FORCE_BUILD_VENDOR_PKG)
   # Pre-strip libtorch_cpu.so so dh_strip's objcopy doesn't fail on its
   # non-standard ELF section table on the buildfarm.
   install(CODE "
-    set(_lt \"\${CMAKE_INSTALL_PREFIX}/opt/${PROJECT_NAME}/lib/libtorch_cpu.so\")
+    set(_lt \"\$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/opt/${PROJECT_NAME}/lib/libtorch_cpu.so\")
     if(EXISTS \"\${_lt}\" AND NOT IS_SYMLINK \"\${_lt}\")
       execute_process(
         COMMAND strip --strip-unneeded \"\${_lt}\"

--- a/libtorch_vendor/CMakeLists.txt
+++ b/libtorch_vendor/CMakeLists.txt
@@ -70,14 +70,27 @@ if(NOT LIBTORCH_CUDA_VERSION STREQUAL "cpu" AND NOT CMAKE_CUDA_ARCHITECTURES)
 endif()
 
 # PyTorch publishes pre-built LibTorch archives for x86_64 only. For aarch64,
-# this vendor package supports only the NVIDIA Tegra platform (Jetson), where
-# PyTorch/LibTorch is shipped with JetPack and must be reused rather than
-# downloaded. The check below treats aarch64 as Tegra and routes it to that
-# reuse path.
+# this vendor package has only been verified on the NVIDIA Tegra platform
+# (Jetson), where PyTorch/LibTorch ships with JetPack and must be reused rather
+# than downloaded. Tegra is identified by the kernel device-tree rather than by
+# aarch64 alone, since not all aarch64 systems are Tegra.
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _system_arch)
 if(_system_arch MATCHES "aarch64|arm64")
-  set(_is_tegra TRUE)
+  set(_is_aarch64 TRUE)
+  set(_is_tegra FALSE)
+  # The device-tree 'compatible' string holds several null-separated entries,
+  # one of which is an "nvidia,tegra..." value (not necessarily the first). Read
+  # it as hex so the nulls don't truncate it, and derive the needle with
+  # string(HEX) to avoid a hard-coded hex literal.
+  if(EXISTS "/proc/device-tree/compatible")
+    file(READ "/proc/device-tree/compatible" _dt_compat_hex HEX)
+    string(HEX "nvidia,tegra" _tegra_needle_hex)
+    if(_dt_compat_hex MATCHES "${_tegra_needle_hex}")
+      set(_is_tegra TRUE)
+    endif()
+  endif()
 else()
+  set(_is_aarch64 FALSE)
   set(_is_tegra FALSE)
 endif()
 
@@ -101,6 +114,12 @@ find_package(Torch QUIET)
 
 if(Torch_FOUND AND NOT FORCE_BUILD_VENDOR_PKG)
   message(STATUS "${PROJECT_NAME}: system LibTorch ${Torch_VERSION} found, skipping download")
+  if(_is_aarch64 AND NOT _is_tegra)
+    message(WARNING
+      "${PROJECT_NAME}: reusing the discovered LibTorch on a non-Tegra aarch64 "
+      "platform. This configuration has only been verified on NVIDIA Tegra "
+      "(Jetson) and is otherwise unverified.")
+  endif()
   set(LIBTORCH_VENDOR_TORCH_DIR "${Torch_DIR}" CACHE PATH
     "Torch_DIR found by libtorch_vendor")
 elseif(_is_tegra)
@@ -111,6 +130,13 @@ elseif(_is_tegra)
     "Ensure the JetPack PyTorch is installed so that 'python3 -c \"import torch\"' "
     "or find_package(Torch) can locate it, then rebuild. Set Torch_DIR explicitly "
     "if it lives in a non-standard location.")
+elseif(_is_aarch64)
+  message(FATAL_ERROR
+    "${PROJECT_NAME}: aarch64 support is only verified on the NVIDIA Tegra "
+    "platform (Jetson), which was not detected here. No pre-built LibTorch "
+    "archive is published for aarch64, so install a compatible LibTorch and "
+    "ensure 'python3 -c \"import torch\"' or find_package(Torch) can locate it "
+    "(set Torch_DIR if needed), then rebuild.")
 else()
   if(Torch_FOUND)
     message(STATUS "${PROJECT_NAME}: forcing vendor build (FORCE_BUILD_VENDOR_PKG)")

--- a/libtorch_vendor/CMakeLists.txt
+++ b/libtorch_vendor/CMakeLists.txt
@@ -51,9 +51,12 @@ if(LIBTORCH_VERSION STREQUAL "")
   endif()
 endif()
 
-# Provide a non-empty CMAKE_CUDA_ARCHITECTURES (required by CMake 3.28+
-# when find_package(Torch) calls enable_language(CUDA)).
-if(NOT CMAKE_CUDA_ARCHITECTURES)
+# A CUDA-built LibTorch makes find_package(Torch) enable the CUDA language,
+# which errors on CMake 3.28+ if CMAKE_CUDA_ARCHITECTURES is empty. This only
+# applies to CUDA variants (in practice the JetPack PyTorch found on Tegra, or
+# a CUDA x86 build); a CPU-only LibTorch never enables CUDA, so skip it there.
+# Seed the arch list from torch when available, else a safe fallback.
+if(NOT LIBTORCH_CUDA_VERSION STREQUAL "cpu" AND NOT CMAKE_CUDA_ARCHITECTURES)
   execute_process(
     COMMAND python3 -c "import torch; print(';'.join(a.split('_',1)[-1] for a in torch.cuda.get_arch_list()))"
     OUTPUT_VARIABLE _torch_arch_list
@@ -62,22 +65,20 @@ if(NOT CMAKE_CUDA_ARCHITECTURES)
     ERROR_QUIET
   )
   if(_torch_arch_rc EQUAL 0 AND _torch_arch_list)
-    set(CMAKE_CUDA_ARCHITECTURES "${_torch_arch_list}" CACHE STRING
-      "CUDA archs (auto-detected by libtorch_vendor)" FORCE)
-  else()
-    set(CMAKE_CUDA_ARCHITECTURES "75" CACHE STRING
-      "CUDA archs (libtorch_vendor fallback, satisfies CMake validation)" FORCE)
+    set(CMAKE_CUDA_ARCHITECTURES "${_torch_arch_list}")
   endif()
 endif()
 
-# PyTorch only publishes pre-built LibTorch archives for x86_64
-# On aarch64 (e.g. NVIDIA Jetson) LibTorch ships within Jetpack,
-# so the platform-provided installation must be reused.
+# PyTorch publishes pre-built LibTorch archives for x86_64 only. For aarch64,
+# this vendor package supports only the NVIDIA Tegra platform (Jetson), where
+# PyTorch/LibTorch is shipped with JetPack and must be reused rather than
+# downloaded. The check below treats aarch64 as Tegra and routes it to that
+# reuse path.
 string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _system_arch)
 if(_system_arch MATCHES "aarch64|arm64")
-  set(_is_aarch64 TRUE)
+  set(_is_tegra TRUE)
 else()
-  set(_is_aarch64 FALSE)
+  set(_is_tegra FALSE)
 endif()
 
 # Help find_package(Torch) locate a pip/system-installed LibTorch. This enables
@@ -102,13 +103,14 @@ if(Torch_FOUND AND NOT FORCE_BUILD_VENDOR_PKG)
   message(STATUS "${PROJECT_NAME}: system LibTorch ${Torch_VERSION} found, skipping download")
   set(LIBTORCH_VENDOR_TORCH_DIR "${Torch_DIR}" CACHE PATH
     "Torch_DIR found by libtorch_vendor")
-elseif(_is_aarch64)
+elseif(_is_tegra)
   message(FATAL_ERROR
     "${PROJECT_NAME}: no pre-built LibTorch archive is published for aarch64. "
-    "On NVIDIA Jetson, LibTorch ships within JetPack, so the platform-provided "
-    "installation must be reused. Ensure the JetPack PyTorch is installed so that "
-    "'python3 -c \"import torch\"' or find_package(Torch) can locate it, then "
-    "rebuild. Set Torch_DIR explicitly if it lives in a non-standard location.")
+    "On the NVIDIA Tegra platform (Jetson / JetPack), LibTorch ships within the "
+    "JetPack PyTorch wheel, so the platform-provided installation must be reused. "
+    "Ensure the JetPack PyTorch is installed so that 'python3 -c \"import torch\"' "
+    "or find_package(Torch) can locate it, then rebuild. Set Torch_DIR explicitly "
+    "if it lives in a non-standard location.")
 else()
   if(Torch_FOUND)
     message(STATUS "${PROJECT_NAME}: forcing vendor build (FORCE_BUILD_VENDOR_PKG)")

--- a/libtorch_vendor/CMakeLists.txt
+++ b/libtorch_vendor/CMakeLists.txt
@@ -78,10 +78,6 @@ string(TOLOWER "${CMAKE_SYSTEM_PROCESSOR}" _system_arch)
 if(_system_arch MATCHES "aarch64|arm64")
   set(_is_aarch64 TRUE)
   set(_is_tegra FALSE)
-  # The device-tree 'compatible' string holds several null-separated entries,
-  # one of which is an "nvidia,tegra..." value (not necessarily the first). Read
-  # it as hex so the nulls don't truncate it, and derive the needle with
-  # string(HEX) to avoid a hard-coded hex literal.
   if(EXISTS "/proc/device-tree/compatible")
     file(READ "/proc/device-tree/compatible" _dt_compat_hex HEX)
     string(HEX "nvidia,tegra" _tegra_needle_hex)

--- a/libtorch_vendor/libtorch_vendor-extras.cmake.in
+++ b/libtorch_vendor/libtorch_vendor-extras.cmake.in
@@ -29,8 +29,13 @@ if(NOT Torch_DIR AND EXISTS "${_@PROJECT_NAME@_vendor_torch_dir}/TorchConfig.cma
 endif()
 unset(_@PROJECT_NAME@_vendor_torch_dir)
 
-# Provide a non-empty CMAKE_CUDA_ARCHITECTURES for downstream consumers
-if(NOT CMAKE_CUDA_ARCHITECTURES)
+# A CUDA-built LibTorch makes downstream find_package(Torch) enable the CUDA
+# language, which errors on CMake 3.28+ if CMAKE_CUDA_ARCHITECTURES is empty.
+# This package was built against the '@LIBTORCH_CUDA_VERSION@' variant, so only
+# seed the arch list for CUDA builds (in practice the JetPack PyTorch on Tegra,
+# or a CUDA x86 build); a CPU-only LibTorch never enables CUDA. Consumers that
+# set CMAKE_CUDA_ARCHITECTURES themselves take precedence.
+if(NOT "@LIBTORCH_CUDA_VERSION@" STREQUAL "cpu" AND NOT CMAKE_CUDA_ARCHITECTURES)
   execute_process(
     COMMAND python3 -c "import torch; print(';'.join(a.split('_',1)[-1] for a in torch.cuda.get_arch_list()))"
     OUTPUT_VARIABLE _@PROJECT_NAME@_torch_arch_list
@@ -39,11 +44,7 @@ if(NOT CMAKE_CUDA_ARCHITECTURES)
     ERROR_QUIET
   )
   if(_@PROJECT_NAME@_torch_arch_rc EQUAL 0 AND _@PROJECT_NAME@_torch_arch_list)
-    set(CMAKE_CUDA_ARCHITECTURES "${_@PROJECT_NAME@_torch_arch_list}" CACHE STRING
-      "CUDA archs (auto-detected by libtorch_vendor)" FORCE)
-  else()
-    set(CMAKE_CUDA_ARCHITECTURES "75" CACHE STRING
-      "CUDA archs (libtorch_vendor fallback, satisfies CMake validation)" FORCE)
+    set(CMAKE_CUDA_ARCHITECTURES "${_@PROJECT_NAME@_torch_arch_list}")
   endif()
   unset(_@PROJECT_NAME@_torch_arch_list)
   unset(_@PROJECT_NAME@_torch_arch_rc)

--- a/libtorch_vendor/libtorch_vendor-extras.cmake.in
+++ b/libtorch_vendor/libtorch_vendor-extras.cmake.in
@@ -12,14 +12,40 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Only point Torch_DIR at the vendored install tree if it actually exists.
-# When a system LibTorch was found at build time we skip the download,
-# so the vendor tree is not present and downstream consumers should
-# continue to find Torch via their own CMAKE_PREFIX_PATH.
+# Prefer the system LibTorch used to build this vendor package. If this package
+# installed a vendored LibTorch tree instead, fall back to that install tree.
+set(_@PROJECT_NAME@_system_torch_dir "@LIBTORCH_VENDOR_TORCH_DIR@")
+if(NOT Torch_DIR AND NOT "${_@PROJECT_NAME@_system_torch_dir}" STREQUAL "")
+  set(Torch_DIR "${_@PROJECT_NAME@_system_torch_dir}")
+  message(STATUS "@PROJECT_NAME@: using system LibTorch at '${Torch_DIR}'")
+endif()
+unset(_@PROJECT_NAME@_system_torch_dir)
+
 set(_@PROJECT_NAME@_vendor_torch_dir
-  "${@PROJECT_NAME@_DIR}/../../../opt/@PROJECT_NAME@/share/cmake/Torch")
+  "${PACKAGE_PREFIX_DIR}/opt/@PROJECT_NAME@/share/cmake/Torch")
 if(NOT Torch_DIR AND EXISTS "${_@PROJECT_NAME@_vendor_torch_dir}/TorchConfig.cmake")
   set(Torch_DIR "${_@PROJECT_NAME@_vendor_torch_dir}")
   message(STATUS "@PROJECT_NAME@: using vendored LibTorch at '${Torch_DIR}'")
 endif()
 unset(_@PROJECT_NAME@_vendor_torch_dir)
+
+# Provide a non-empty CMAKE_CUDA_ARCHITECTURES for downstream consumers
+if(NOT CMAKE_CUDA_ARCHITECTURES)
+  execute_process(
+    COMMAND python3 -c "import torch; print(';'.join(a.split('_',1)[-1] for a in torch.cuda.get_arch_list()))"
+    OUTPUT_VARIABLE _@PROJECT_NAME@_torch_arch_list
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+    RESULT_VARIABLE _@PROJECT_NAME@_torch_arch_rc
+    ERROR_QUIET
+  )
+  if(_@PROJECT_NAME@_torch_arch_rc EQUAL 0 AND _@PROJECT_NAME@_torch_arch_list)
+    set(CMAKE_CUDA_ARCHITECTURES "${_@PROJECT_NAME@_torch_arch_list}" CACHE STRING
+      "CUDA archs (auto-detected by libtorch_vendor)" FORCE)
+  else()
+    set(CMAKE_CUDA_ARCHITECTURES "75" CACHE STRING
+      "CUDA archs (libtorch_vendor fallback, satisfies CMake validation)" FORCE)
+  endif()
+  unset(_@PROJECT_NAME@_torch_arch_list)
+  unset(_@PROJECT_NAME@_torch_arch_rc)
+endif()
+


### PR DESCRIPTION
## Description
Adds NVIDIA Tegra (Jetson) support to `libtorch_vendor`:
- **aarch64/Tegra:** PyTorch ships no aarch64 LibTorch archive, so on Jetson
  the platform JetPack PyTorch is reused instead of downloaded. If it's missing,
  the build fails fast with an error message.
- **Reuse if present:** a `python3 -c "import torch"` probe sets `Torch_DIR`, so
  an already-installed LibTorch (JetPack on aarch64, or pip/conda on x86) is
  reused; x86 still downloads when none is found.
- **Debian packaging:** the `libtorch_cpu.so` pre-strip now honors `$DESTDIR`
  so `dh_strip` succeeds during `dpkg-buildpackage` on the buildfarm.
- **CudaBufferDescriptor:**  Removes the unused `serialized_data `field from CudaBufferDescriptor (and its dead receive-side branch in the backend - plugin), since it was never populated by any publisher.

### Is this user-facing behavior change?
No

### Did you use Generative AI?
Yes — Cursor (Claude) assisted with the CMake logic and comments.

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
