### PR TITLE
Add cuda_buffer_py

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ PyTorch-side helper library that builds on the same buffer infrastructure.
 
 - **cuda_buffer** -- Core CUDA buffer library (VMM-backed IPC memory pool,
   host endpoint manager, ReadHandle/WriteHandle with CUDA event sync).
+- **cuda_buffer_py** -- Python CUDA buffer allocation and scoped read/write
+  handles for rclpy publishers and subscribers.
 - **cuda_buffer_backend** -- BufferBackend plugin for CUDA IPC transport.
 - **cuda_buffer_backend_msgs** -- ROS 2 message definitions for CUDA buffer
   descriptors.

--- a/cuda_buffer_backend/README.md
+++ b/cuda_buffer_backend/README.md
@@ -15,14 +15,14 @@ rosdep install --from-paths src --ignore-src -y \
   --skip-keys "fastcdr rti-connext-dds-7.7.0 urdfdom_headers qt6-svg-dev"
 
 # Build the CUDA backend.
-colcon build --symlink-install --packages-up-to cuda_buffer_backend
+colcon build --symlink-install --packages-up-to cuda_buffer_backend cuda_buffer_py
 source install/setup.sh
 ```
 
 ## Test
 
 ```bash
-colcon test --packages-select cuda_buffer cuda_buffer_backend
+colcon test --packages-select cuda_buffer cuda_buffer_py cuda_buffer_backend
 colcon test-result --verbose
 ```
 
@@ -31,6 +31,7 @@ colcon test-result --verbose
 | Package | Description |
 |---|---|
 | `cuda_buffer` | Core CUDA buffer implementation: memory pool, IPC manager, host endpoint manager, and user-facing `allocate_buffer` / `from_input_buffer` / `from_output_buffer` / `to_buffer` APIs |
+| `cuda_buffer_py` | Python CUDA buffer allocation plus scoped read/write handles for rclpy publishers and subscribers |
 | `cuda_buffer_backend` | Plugin registration via `pluginlib`, endpoint discovery, and descriptor serialization |
 | `cuda_buffer_backend_msgs` | ROS 2 message definition for `CudaBufferDescriptor` |
 
@@ -137,6 +138,108 @@ cuda_buffer_backend::ReadHandle rh =
   const and mutable arguments (const-ref binding). `ReadHandle::get_ptr()` returns
   `const uint8_t *` — the type system prevents subscribers from writing
   through the handle.
+
+### Python (rclpy)
+
+The `cuda_buffer_py` package exposes the same scoped input/output model to
+rclpy. For a direct CUDA producer, allocate device storage and write it on the
+same stream used by the producing kernel:
+
+```python
+from cuda_buffer import CudaBuffer
+from sensor_msgs.msg import Image
+
+stream_ptr = get_current_cuda_stream_ptr()
+
+msg = Image()
+msg.height = 480
+msg.width = 640
+msg.encoding = 'rgb8'
+msg.step = 640 * 3
+msg.data = CudaBuffer.allocate_buffer(msg.height * msg.step)
+
+with CudaBuffer.from_output_buffer(msg.data, stream_ptr) as write_handle:
+    produce_device_data(
+        write_handle.device_ptr,
+        len(msg.data),
+        stream_ptr,
+    )
+
+publisher.publish(msg)
+```
+
+Leaving the context records the producer event on `stream_ptr`; it does not
+synchronize the stream. `write_handle.buffer` holds the CUDA buffer and is
+useful when `from_output_buffer()` promotes a non-CUDA value based on its size:
+
+```python
+with CudaBuffer.from_output_buffer(msg.data, stream_ptr) as write_handle:
+    msg.data = write_handle.buffer
+    produce_device_data(write_handle.device_ptr, len(msg.data), stream_ptr)
+```
+
+For CPU-originated data, `from_cpu()` copies bytes to device memory, while
+`from_size()` creates a zero-initialized device buffer. These convenience
+factories synchronize their initialization before returning:
+
+```python
+from cuda_buffer import CudaBuffer
+from sensor_msgs.msg import Image
+
+msg = Image()
+msg.height = 480
+msg.width = 640
+msg.encoding = 'rgb8'
+msg.step = 640 * 3
+msg.data = CudaBuffer.from_cpu(host_image_bytes)
+publisher.publish(msg)
+```
+
+Python subscribers can acquire the same scoped CUDA read access as the C++
+`from_input_buffer()` API. Pass the CUDA stream that will consume the data as
+an integer pointer; CPU fallback data is promoted automatically:
+
+```python
+from cuda_buffer import CudaBuffer
+
+def callback(msg):
+    stream_ptr = get_current_cuda_stream_ptr()
+    with CudaBuffer.from_input_buffer(msg.data, stream_ptr) as read_handle:
+        consume_device_data(
+            read_handle.device_ptr,
+            len(msg.data),
+            stream_ptr,
+        )
+```
+
+For an existing CUDA-backed field, `from_input_buffer()` only enqueues a wait
+for the producer event on the consumer stream. The handle keeps the source or
+promoted CUDA buffer alive, and leaving the context records a read event so the
+backend does not recycle the allocation before queued work completes. There is
+no CPU conversion or stream synchronization in this CUDA-to-CUDA path. If no
+stream is supplied, the backend's process-lifetime internal stream is used.
+CPU fallback input is promoted with an asynchronous host-to-device copy on the
+selected stream.
+
+Subscribers opt in to delivery through the CUDA backend with rclpy's
+`acceptable_buffer_backends` argument. CPU remains an implicit fallback when
+CUDA IPC is unavailable:
+
+```python
+subscription = node.create_subscription(
+    Image,
+    'image',
+    callback,
+    10,
+    acceptable_buffer_backends='cuda',
+)
+
+def callback(msg):
+    if getattr(msg.data, 'backend_type', 'cpu') == 'cuda':
+        host_image_bytes = msg.data.to_bytes()
+    else:
+        host_image_bytes = bytes(msg.data)
+```
 
 ## IPC Behavior
 

--- a/cuda_buffer_backend/cuda_buffer_py/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer_py/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 3.20)
+project(cuda_buffer_py)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(cuda_buffer REQUIRED)
+find_package(rosidl_buffer REQUIRED)
+
+# Work around Ubuntu's split nvidia-cuda-dev layout in bloom builds.
+find_path(_CUDA_RUNTIME_DIR
+  NAMES cuda_runtime.h
+  HINTS
+    ENV CUDA_HOME
+    ENV CUDA_PATH
+    /usr/local/cuda/include
+    /usr/include
+)
+if(_CUDA_RUNTIME_DIR AND NOT DEFINED CUDAToolkit_INCLUDE_DIRECTORIES)
+  set(CUDAToolkit_INCLUDE_DIRECTORIES "${_CUDA_RUNTIME_DIR}" CACHE PATH
+    "CUDA include dir (FindCUDAToolkit nvidia-cuda-dev workaround)")
+endif()
+find_package(CUDAToolkit REQUIRED)
+
+# Find Python before pybind11 so both use the same interpreter.
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(pybind11 REQUIRED)
+
+pybind11_add_module(_cuda_buffer_py
+  src/cuda_buffer_py.cpp
+)
+
+target_link_libraries(_cuda_buffer_py PRIVATE
+  CUDA::cudart
+  cuda_buffer::cuda_buffer
+  rosidl_buffer::rosidl_buffer
+)
+
+# Install the Python package first so ament defines PYTHON_INSTALL_DIR.
+ament_python_install_package(cuda_buffer)
+
+install(TARGETS _cuda_buffer_py
+  DESTINATION "${PYTHON_INSTALL_DIR}/cuda_buffer"
+)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_pytest REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_add_pytest_test(test_cuda_buffer_py
+    test/test_cuda_buffer_py.py
+    TIMEOUT 60
+  )
+
+  ament_add_pytest_test(test_cuda_buffer_py_pubsub
+    test/test_cuda_buffer_py_pubsub.py
+    TIMEOUT 40
+  )
+endif()
+
+ament_package()

--- a/cuda_buffer_backend/cuda_buffer_py/cuda_buffer/__init__.py
+++ b/cuda_buffer_backend/cuda_buffer_py/cuda_buffer/__init__.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Python factories for CUDA-backed ROS 2 buffers."""
+
+from collections.abc import Sized
+from typing import Iterable
+from typing import Optional
+from typing import Union
+
+from cuda_buffer._cuda_buffer_py import _allocate_buffer
+from cuda_buffer._cuda_buffer_py import _from_cpu_data
+from cuda_buffer._cuda_buffer_py import _from_input_buffer
+from cuda_buffer._cuda_buffer_py import _from_input_cpu_data
+from cuda_buffer._cuda_buffer_py import _from_output_buffer
+from cuda_buffer._cuda_buffer_py import _from_size
+from cuda_buffer._cuda_buffer_py import CudaReadHandle
+from cuda_buffer._cuda_buffer_py import CudaWriteHandle
+from rosidl_buffer import Buffer
+
+
+class CudaBuffer:
+    """Create CUDA-backed :class:`rosidl_buffer.Buffer` objects."""
+
+    @staticmethod
+    def from_cpu(data: Union[bytes, bytearray, Iterable[int]]) -> Buffer:
+        """Copy CPU byte data into a new CUDA-backed buffer."""
+        if not isinstance(data, bytes):
+            data = bytes(data)
+        return _from_cpu_data(data)
+
+    @staticmethod
+    def from_size(size: int) -> Buffer:
+        """Create a zero-initialized CUDA-backed buffer with ``size`` bytes."""
+        return _from_size(size)
+
+    @staticmethod
+    def allocate_buffer(size: int) -> Buffer:
+        """Allocate an uninitialized CUDA-backed buffer without synchronizing."""
+        return _allocate_buffer(size)
+
+    @staticmethod
+    def from_output_buffer(
+        buffer: Union[Buffer, bytes, bytearray, Iterable[int]],
+        stream: Optional[int] = None,
+    ) -> CudaWriteHandle:
+        """
+        Acquire scoped write access to output data on a CUDA stream.
+
+        A non-CUDA input supplies the output size only and is replaced by the
+        CUDA-backed ``handle.buffer``. ``stream`` is a CUDA stream pointer
+        represented as an integer. When omitted, the backend's internal
+        stream is used.
+        """
+        if not isinstance(buffer, Buffer) or buffer.backend_type != 'cuda':
+            if isinstance(buffer, Sized):
+                size = len(buffer)
+            else:
+                size = len(bytes(buffer))
+            buffer = _allocate_buffer(size)
+        return _from_output_buffer(buffer, stream)
+
+    @staticmethod
+    def from_input_buffer(
+        buffer: Union[Buffer, bytes, bytearray, Iterable[int]],
+        stream: Optional[int] = None,
+    ) -> CudaReadHandle:
+        """
+        Acquire scoped read access to input data on a CUDA stream.
+
+        Non-CUDA input is promoted to a CUDA buffer and retained by the
+        returned handle. ``stream`` is a CUDA stream pointer represented as
+        an integer. When omitted, the backend's internal stream is used.
+        """
+        if isinstance(buffer, Buffer):
+            return _from_input_buffer(buffer, stream)
+        if not isinstance(buffer, bytes):
+            buffer = bytes(buffer)
+        return _from_input_cpu_data(buffer, stream)
+
+
+__all__ = ['CudaBuffer', 'CudaReadHandle', 'CudaWriteHandle']

--- a/cuda_buffer_backend/cuda_buffer_py/cuda_buffer/_cuda_buffer_py.pyi
+++ b/cuda_buffer_backend/cuda_buffer_py/cuda_buffer/_cuda_buffer_py.pyi
@@ -1,0 +1,70 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from types import TracebackType
+from typing import Optional
+from typing import Type
+
+from rosidl_buffer import Buffer
+
+
+class CudaReadHandle:
+    @property
+    def device_ptr(self) -> int: ...
+    @property
+    def closed(self) -> bool: ...
+    def get_ptr(self) -> int: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> CudaReadHandle: ...
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool: ...
+
+
+class CudaWriteHandle:
+    @property
+    def device_ptr(self) -> int: ...
+    @property
+    def buffer(self) -> Buffer: ...
+    @property
+    def closed(self) -> bool: ...
+    def get_ptr(self) -> int: ...
+    def close(self) -> None: ...
+    def __enter__(self) -> CudaWriteHandle: ...
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> bool: ...
+
+
+def _from_cpu_data(data: bytes) -> Buffer: ...
+def _from_size(size: int) -> Buffer: ...
+def _allocate_buffer(size: int) -> Buffer: ...
+def _from_output_buffer(
+    buffer: Buffer,
+    stream: Optional[int] = None,
+) -> CudaWriteHandle: ...
+def _from_input_buffer(
+    buffer: Buffer,
+    stream: Optional[int] = None,
+) -> CudaReadHandle: ...
+def _from_input_cpu_data(
+    data: bytes,
+    stream: Optional[int] = None,
+) -> CudaReadHandle: ...

--- a/cuda_buffer_backend/cuda_buffer_py/cuda_buffer/py.typed
+++ b/cuda_buffer_backend/cuda_buffer_py/cuda_buffer/py.typed
@@ -1,0 +1,1 @@
+See https://peps.python.org/pep-0561/ for details about py.typed files.

--- a/cuda_buffer_backend/cuda_buffer_py/package.xml
+++ b/cuda_buffer_backend/cuda_buffer_py/package.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>cuda_buffer_py</name>
+  <version>0.1.2</version>
+  <description>Python bindings for creating CUDA-backed rosidl buffers for rclpy.</description>
+
+  <maintainer email="yuankunz@nvidia.com">Yuankun Zhu</maintainer>
+  <license>Apache-2.0</license>
+  <author email="yuankunz@nvidia.com">Yuankun Zhu</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
+
+  <depend>cuda_buffer</depend>
+  <depend>rosidl_buffer</depend>
+  <depend>rosidl_buffer_py</depend>
+
+  <exec_depend>cuda_buffer_backend</exec_depend>
+
+  <build_depend>pybind11-dev</build_depend>
+  <build_depend>python3-dev</build_depend>
+
+  <test_depend>ament_cmake_pytest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+  <test_depend>rclpy</test_depend>
+  <test_depend>sensor_msgs</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/cuda_buffer_backend/cuda_buffer_py/src/cuda_buffer_py.cpp
+++ b/cuda_buffer_backend/cuda_buffer_py/src/cuda_buffer_py.cpp
@@ -1,0 +1,271 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <pybind11/pybind11.h>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "cuda_buffer/cuda_buffer_api.hpp"
+#include "rosidl_buffer/buffer.hpp"
+
+namespace py = pybind11;
+
+namespace
+{
+
+class PyCudaReadHandle
+{
+public:
+  PyCudaReadHandle(
+    cuda_buffer_backend::ReadHandle && handle,
+    py::object owner)
+  : owner_(std::move(owner)), handle_(std::move(handle))
+  {
+  }
+
+  PyCudaReadHandle(const PyCudaReadHandle &) = delete;
+  PyCudaReadHandle & operator=(const PyCudaReadHandle &) = delete;
+  PyCudaReadHandle(PyCudaReadHandle &&) = default;
+  PyCudaReadHandle & operator=(PyCudaReadHandle &&) = default;
+
+  uintptr_t get_ptr() const
+  {
+    if (!handle_) {
+      throw std::runtime_error("CudaReadHandle is closed");
+    }
+    return reinterpret_cast<uintptr_t>(handle_->get_ptr());
+  }
+
+  bool is_closed() const {return !handle_.has_value();}
+
+  void close()
+  {
+    handle_.reset();
+    owner_ = py::none();
+  }
+
+private:
+  // Keep the Python Buffer alive until after ReadHandle records its read event.
+  py::object owner_;
+  std::optional<cuda_buffer_backend::ReadHandle> handle_;
+};
+
+class PyCudaWriteHandle
+{
+public:
+  PyCudaWriteHandle(
+    cuda_buffer_backend::WriteHandle && handle,
+    py::object buffer)
+  : buffer_(std::move(buffer)), handle_(std::move(handle))
+  {
+  }
+
+  PyCudaWriteHandle(const PyCudaWriteHandle &) = delete;
+  PyCudaWriteHandle & operator=(const PyCudaWriteHandle &) = delete;
+  PyCudaWriteHandle(PyCudaWriteHandle &&) = default;
+  PyCudaWriteHandle & operator=(PyCudaWriteHandle &&) = default;
+
+  uintptr_t get_ptr()
+  {
+    if (!handle_) {
+      throw std::runtime_error("CudaWriteHandle is closed");
+    }
+    return reinterpret_cast<uintptr_t>(handle_->get_ptr());
+  }
+
+  bool is_closed() const {return !handle_.has_value();}
+
+  py::object get_buffer() const {return buffer_;}
+
+  void close()
+  {
+    // Keep buffer_ available after close so callers can assign a promoted
+    // output buffer to their message after the write event is recorded.
+    handle_.reset();
+  }
+
+private:
+  // Declared before handle_ so the WriteHandle is destroyed first and can
+  // record its event while the underlying CUDA allocation is still alive.
+  py::object buffer_;
+  std::optional<cuda_buffer_backend::WriteHandle> handle_;
+};
+
+cudaStream_t stream_from_python(const py::object & stream)
+{
+  if (stream.is_none()) {
+    return cuda_buffer_backend::get_internal_stream();
+  }
+  return reinterpret_cast<cudaStream_t>(stream.cast<uintptr_t>());
+}
+
+py::object wrap_cuda_buffer(std::unique_ptr<rosidl::Buffer<uint8_t>> buffer)
+{
+  py::module_ rosidl_buffer_module = py::module_::import("rosidl_buffer._rosidl_buffer_py");
+  return rosidl_buffer_module.attr("_take_buffer_from_ptr")(
+    reinterpret_cast<uintptr_t>(buffer.release()));
+}
+
+std::unique_ptr<rosidl::Buffer<uint8_t>> allocate_and_copy(
+  const void * data, size_t size)
+{
+  auto buffer = std::make_unique<rosidl::Buffer<uint8_t>>(
+    cuda_buffer_backend::allocate_buffer(size));
+
+  if (size > 0) {
+    cudaStream_t stream = cuda_buffer_backend::get_internal_stream();
+    {
+      auto write_handle = cuda_buffer_backend::from_output_buffer(*buffer, stream);
+      cuda_buffer_backend::to_buffer(
+        data, size, write_handle, stream, cudaMemcpyHostToDevice);
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+  }
+
+  return buffer;
+}
+
+std::unique_ptr<rosidl::Buffer<uint8_t>> allocate_zeroed(size_t size)
+{
+  auto buffer = std::make_unique<rosidl::Buffer<uint8_t>>(
+    cuda_buffer_backend::allocate_buffer(size));
+
+  if (size > 0) {
+    cudaStream_t stream = cuda_buffer_backend::get_internal_stream();
+    {
+      auto write_handle = cuda_buffer_backend::from_output_buffer(*buffer, stream);
+      CUDA_CHECK(cudaMemsetAsync(write_handle.get_ptr(), 0, size, stream));
+    }
+    CUDA_CHECK(cudaStreamSynchronize(stream));
+  }
+
+  return buffer;
+}
+
+}  // namespace
+
+PYBIND11_MODULE(_cuda_buffer_py, module)
+{
+  module.doc() = "Python bindings for creating CUDA-backed rosidl buffers";
+
+  py::class_<PyCudaReadHandle>(module, "CudaReadHandle")
+  .def_property_readonly("device_ptr", &PyCudaReadHandle::get_ptr)
+  .def_property_readonly("closed", &PyCudaReadHandle::is_closed)
+  .def("get_ptr", &PyCudaReadHandle::get_ptr)
+  .def("close", &PyCudaReadHandle::close)
+  .def(
+    "__enter__",
+    [](PyCudaReadHandle & self) -> PyCudaReadHandle & {
+      (void)self.get_ptr();
+      return self;
+    },
+    py::return_value_policy::reference_internal)
+  .def(
+    "__exit__",
+    [](PyCudaReadHandle & self, py::object, py::object, py::object) {
+      self.close();
+      return false;
+    });
+
+  py::class_<PyCudaWriteHandle>(module, "CudaWriteHandle")
+  .def_property_readonly("device_ptr", &PyCudaWriteHandle::get_ptr)
+  .def_property_readonly("buffer", &PyCudaWriteHandle::get_buffer)
+  .def_property_readonly("closed", &PyCudaWriteHandle::is_closed)
+  .def("get_ptr", &PyCudaWriteHandle::get_ptr)
+  .def("close", &PyCudaWriteHandle::close)
+  .def(
+    "__enter__",
+    [](PyCudaWriteHandle & self) -> PyCudaWriteHandle & {
+      (void)self.get_ptr();
+      return self;
+    },
+    py::return_value_policy::reference_internal)
+  .def(
+    "__exit__",
+    [](PyCudaWriteHandle & self, py::object, py::object, py::object) {
+      self.close();
+      return false;
+    });
+
+  module.def(
+    "_from_cpu_data",
+    [](py::bytes data) {
+      std::string bytes = data;
+      return wrap_cuda_buffer(allocate_and_copy(bytes.data(), bytes.size()));
+    },
+    py::arg("data"));
+
+  module.def(
+    "_from_size",
+    [](size_t size) {
+      return wrap_cuda_buffer(allocate_zeroed(size));
+    },
+    py::arg("size"));
+
+  module.def(
+    "_allocate_buffer",
+    [](size_t size) {
+      auto buffer = std::make_unique<rosidl::Buffer<uint8_t>>(
+        cuda_buffer_backend::allocate_buffer(size));
+      return wrap_cuda_buffer(std::move(buffer));
+    },
+    py::arg("size"));
+
+  module.def(
+    "_from_output_buffer",
+    [](py::object buffer, py::object stream) {
+      py::module_ rosidl_buffer_module = py::module_::import(
+        "rosidl_buffer._rosidl_buffer_py");
+      uintptr_t ptr = rosidl_buffer_module.attr("_get_buffer_ptr")(buffer).cast<uintptr_t>();
+      auto * cpp_buffer = reinterpret_cast<rosidl::Buffer<uint8_t> *>(ptr);
+      auto write_handle = cuda_buffer_backend::from_output_buffer(
+        *cpp_buffer, stream_from_python(stream));
+      return PyCudaWriteHandle(std::move(write_handle), std::move(buffer));
+    },
+    py::arg("buffer"),
+    py::arg("stream") = py::none());
+
+  module.def(
+    "_from_input_buffer",
+    [](py::object buffer, py::object stream) {
+      py::module_ rosidl_buffer_module = py::module_::import(
+        "rosidl_buffer._rosidl_buffer_py");
+      uintptr_t ptr = rosidl_buffer_module.attr("_get_buffer_ptr")(buffer).cast<uintptr_t>();
+      auto * cpp_buffer = reinterpret_cast<rosidl::Buffer<uint8_t> *>(ptr);
+      auto read_handle = cuda_buffer_backend::from_input_buffer(
+        *cpp_buffer, stream_from_python(stream));
+      return PyCudaReadHandle(std::move(read_handle), std::move(buffer));
+    },
+    py::arg("buffer"),
+    py::arg("stream") = py::none());
+
+  module.def(
+    "_from_input_cpu_data",
+    [](py::bytes data, py::object stream) {
+      std::string bytes = data;
+      std::vector<uint8_t> storage(bytes.begin(), bytes.end());
+      rosidl::Buffer<uint8_t> cpu_buffer(std::move(storage));
+      auto read_handle = cuda_buffer_backend::from_input_buffer(
+        cpu_buffer, stream_from_python(stream));
+      return PyCudaReadHandle(std::move(read_handle), py::none());
+    },
+    py::arg("data"),
+    py::arg("stream") = py::none());
+}

--- a/cuda_buffer_backend/cuda_buffer_py/src/cuda_buffer_py.cpp
+++ b/cuda_buffer_backend/cuda_buffer_py/src/cuda_buffer_py.cpp
@@ -30,20 +30,20 @@ namespace py = pybind11;
 namespace
 {
 
-class PyCudaReadHandle
+class CudaReadHandleWrapper
 {
 public:
-  PyCudaReadHandle(
+  CudaReadHandleWrapper(
     cuda_buffer_backend::ReadHandle && handle,
     py::object owner)
   : owner_(std::move(owner)), handle_(std::move(handle))
   {
   }
 
-  PyCudaReadHandle(const PyCudaReadHandle &) = delete;
-  PyCudaReadHandle & operator=(const PyCudaReadHandle &) = delete;
-  PyCudaReadHandle(PyCudaReadHandle &&) = default;
-  PyCudaReadHandle & operator=(PyCudaReadHandle &&) = default;
+  CudaReadHandleWrapper(const CudaReadHandleWrapper &) = delete;
+  CudaReadHandleWrapper & operator=(const CudaReadHandleWrapper &) = delete;
+  CudaReadHandleWrapper(CudaReadHandleWrapper &&) = default;
+  CudaReadHandleWrapper & operator=(CudaReadHandleWrapper &&) = default;
 
   uintptr_t get_ptr() const
   {
@@ -67,20 +67,20 @@ private:
   std::optional<cuda_buffer_backend::ReadHandle> handle_;
 };
 
-class PyCudaWriteHandle
+class CudaWriteHandleWrapper
 {
 public:
-  PyCudaWriteHandle(
+  CudaWriteHandleWrapper(
     cuda_buffer_backend::WriteHandle && handle,
     py::object buffer)
   : buffer_(std::move(buffer)), handle_(std::move(handle))
   {
   }
 
-  PyCudaWriteHandle(const PyCudaWriteHandle &) = delete;
-  PyCudaWriteHandle & operator=(const PyCudaWriteHandle &) = delete;
-  PyCudaWriteHandle(PyCudaWriteHandle &&) = default;
-  PyCudaWriteHandle & operator=(PyCudaWriteHandle &&) = default;
+  CudaWriteHandleWrapper(const CudaWriteHandleWrapper &) = delete;
+  CudaWriteHandleWrapper & operator=(const CudaWriteHandleWrapper &) = delete;
+  CudaWriteHandleWrapper(CudaWriteHandleWrapper &&) = default;
+  CudaWriteHandleWrapper & operator=(CudaWriteHandleWrapper &&) = default;
 
   uintptr_t get_ptr()
   {
@@ -165,41 +165,41 @@ PYBIND11_MODULE(_cuda_buffer_py, module)
 {
   module.doc() = "Python bindings for creating CUDA-backed rosidl buffers";
 
-  py::class_<PyCudaReadHandle>(module, "CudaReadHandle")
-  .def_property_readonly("device_ptr", &PyCudaReadHandle::get_ptr)
-  .def_property_readonly("closed", &PyCudaReadHandle::is_closed)
-  .def("get_ptr", &PyCudaReadHandle::get_ptr)
-  .def("close", &PyCudaReadHandle::close)
+  py::class_<CudaReadHandleWrapper>(module, "CudaReadHandle")
+  .def_property_readonly("device_ptr", &CudaReadHandleWrapper::get_ptr)
+  .def_property_readonly("closed", &CudaReadHandleWrapper::is_closed)
+  .def("get_ptr", &CudaReadHandleWrapper::get_ptr)
+  .def("close", &CudaReadHandleWrapper::close)
   .def(
     "__enter__",
-    [](PyCudaReadHandle & self) -> PyCudaReadHandle & {
+    [](CudaReadHandleWrapper & self) -> CudaReadHandleWrapper & {
       (void)self.get_ptr();
       return self;
     },
     py::return_value_policy::reference_internal)
   .def(
     "__exit__",
-    [](PyCudaReadHandle & self, py::object, py::object, py::object) {
+    [](CudaReadHandleWrapper & self, py::object, py::object, py::object) {
       self.close();
       return false;
     });
 
-  py::class_<PyCudaWriteHandle>(module, "CudaWriteHandle")
-  .def_property_readonly("device_ptr", &PyCudaWriteHandle::get_ptr)
-  .def_property_readonly("buffer", &PyCudaWriteHandle::get_buffer)
-  .def_property_readonly("closed", &PyCudaWriteHandle::is_closed)
-  .def("get_ptr", &PyCudaWriteHandle::get_ptr)
-  .def("close", &PyCudaWriteHandle::close)
+  py::class_<CudaWriteHandleWrapper>(module, "CudaWriteHandle")
+  .def_property_readonly("device_ptr", &CudaWriteHandleWrapper::get_ptr)
+  .def_property_readonly("buffer", &CudaWriteHandleWrapper::get_buffer)
+  .def_property_readonly("closed", &CudaWriteHandleWrapper::is_closed)
+  .def("get_ptr", &CudaWriteHandleWrapper::get_ptr)
+  .def("close", &CudaWriteHandleWrapper::close)
   .def(
     "__enter__",
-    [](PyCudaWriteHandle & self) -> PyCudaWriteHandle & {
+    [](CudaWriteHandleWrapper & self) -> CudaWriteHandleWrapper & {
       (void)self.get_ptr();
       return self;
     },
     py::return_value_policy::reference_internal)
   .def(
     "__exit__",
-    [](PyCudaWriteHandle & self, py::object, py::object, py::object) {
+    [](CudaWriteHandleWrapper & self, py::object, py::object, py::object) {
       self.close();
       return false;
     });
@@ -237,7 +237,7 @@ PYBIND11_MODULE(_cuda_buffer_py, module)
       auto * cpp_buffer = reinterpret_cast<rosidl::Buffer<uint8_t> *>(ptr);
       auto write_handle = cuda_buffer_backend::from_output_buffer(
         *cpp_buffer, stream_from_python(stream));
-      return PyCudaWriteHandle(std::move(write_handle), std::move(buffer));
+      return CudaWriteHandleWrapper(std::move(write_handle), std::move(buffer));
     },
     py::arg("buffer"),
     py::arg("stream") = py::none());
@@ -251,7 +251,7 @@ PYBIND11_MODULE(_cuda_buffer_py, module)
       auto * cpp_buffer = reinterpret_cast<rosidl::Buffer<uint8_t> *>(ptr);
       auto read_handle = cuda_buffer_backend::from_input_buffer(
         *cpp_buffer, stream_from_python(stream));
-      return PyCudaReadHandle(std::move(read_handle), std::move(buffer));
+      return CudaReadHandleWrapper(std::move(read_handle), std::move(buffer));
     },
     py::arg("buffer"),
     py::arg("stream") = py::none());
@@ -264,7 +264,7 @@ PYBIND11_MODULE(_cuda_buffer_py, module)
       rosidl::Buffer<uint8_t> cpu_buffer(std::move(storage));
       auto read_handle = cuda_buffer_backend::from_input_buffer(
         cpu_buffer, stream_from_python(stream));
-      return PyCudaReadHandle(std::move(read_handle), py::none());
+      return CudaReadHandleWrapper(std::move(read_handle), py::none());
     },
     py::arg("data"),
     py::arg("stream") = py::none());

--- a/cuda_buffer_backend/cuda_buffer_py/test/test_cuda_buffer_py.py
+++ b/cuda_buffer_backend/cuda_buffer_py/test/test_cuda_buffer_py.py
@@ -1,0 +1,135 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from cuda_buffer import CudaBuffer
+from cuda_buffer import CudaReadHandle
+from cuda_buffer import CudaWriteHandle
+import pytest
+from rosidl_buffer import Buffer
+
+
+def test_from_cpu_bytes():
+    data = bytes(range(32))
+
+    buffer = CudaBuffer.from_cpu(data)
+
+    assert isinstance(buffer, Buffer)
+    assert buffer.backend_type == 'cuda'
+    assert len(buffer) == len(data)
+    assert buffer.to_bytes() == data
+
+
+def test_from_cpu_iterable():
+    buffer = CudaBuffer.from_cpu(range(16))
+
+    assert buffer.backend_type == 'cuda'
+    assert buffer.to_bytes() == bytes(range(16))
+
+
+def test_from_size_is_zero_initialized():
+    buffer = CudaBuffer.from_size(64)
+
+    assert buffer.backend_type == 'cuda'
+    assert len(buffer) == 64
+    assert buffer.to_bytes() == bytes(64)
+
+
+def test_empty_buffer():
+    buffer = CudaBuffer.from_cpu(b'')
+
+    assert buffer.backend_type == 'cuda'
+    assert len(buffer) == 0
+    assert buffer.to_bytes() == b''
+
+
+def test_allocate_buffer_is_uninitialized_cuda_storage():
+    buffer = CudaBuffer.allocate_buffer(64)
+
+    assert isinstance(buffer, Buffer)
+    assert buffer.backend_type == 'cuda'
+    assert len(buffer) == 64
+
+
+def test_from_output_cuda_buffer():
+    buffer = CudaBuffer.allocate_buffer(64)
+
+    with CudaBuffer.from_output_buffer(buffer) as handle:
+        assert isinstance(handle, CudaWriteHandle)
+        assert handle.buffer is buffer
+        assert handle.device_ptr != 0
+        assert handle.get_ptr() == handle.device_ptr
+        assert not handle.closed
+
+    assert handle.closed
+    assert handle.buffer is buffer
+    with pytest.raises(RuntimeError, match='closed'):
+        handle.get_ptr()
+
+
+def test_from_output_cpu_data_promotes_to_cuda():
+    handle = CudaBuffer.from_output_buffer(bytes(32))
+
+    assert isinstance(handle, CudaWriteHandle)
+    assert isinstance(handle.buffer, Buffer)
+    assert handle.buffer.backend_type == 'cuda'
+    assert len(handle.buffer) == 32
+    assert handle.device_ptr != 0
+    handle.close()
+    handle.close()
+    assert handle.closed
+    assert handle.buffer.backend_type == 'cuda'
+
+
+def test_from_output_can_only_be_acquired_once():
+    buffer = CudaBuffer.allocate_buffer(32)
+
+    with CudaBuffer.from_output_buffer(buffer):
+        pass
+
+    with pytest.raises(RuntimeError, match='write.*finalized'):
+        CudaBuffer.from_output_buffer(buffer)
+
+
+def test_from_output_empty_buffer_raises():
+    with pytest.raises(RuntimeError, match='empty buffer'):
+        CudaBuffer.from_output_buffer(b'')
+
+
+def test_from_input_cuda_buffer():
+    buffer = CudaBuffer.from_cpu(bytes(range(32)))
+
+    with CudaBuffer.from_input_buffer(buffer) as handle:
+        assert isinstance(handle, CudaReadHandle)
+        assert handle.device_ptr != 0
+        assert handle.get_ptr() == handle.device_ptr
+        assert not handle.closed
+
+    assert handle.closed
+    with pytest.raises(RuntimeError, match='closed'):
+        handle.get_ptr()
+
+
+def test_from_input_cpu_data_promotes_to_cuda():
+    handle = CudaBuffer.from_input_buffer(bytes(range(32)))
+
+    assert isinstance(handle, CudaReadHandle)
+    assert handle.device_ptr != 0
+    handle.close()
+    handle.close()
+    assert handle.closed
+
+
+def test_from_input_empty_buffer_raises():
+    with pytest.raises(RuntimeError, match='empty buffer'):
+        CudaBuffer.from_input_buffer(b'')

--- a/cuda_buffer_backend/cuda_buffer_py/test/test_cuda_buffer_py_pubsub.py
+++ b/cuda_buffer_backend/cuda_buffer_py/test/test_cuda_buffer_py_pubsub.py
@@ -1,0 +1,149 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+import textwrap
+import time
+import uuid
+
+
+def test_multiprocess_rclpy_cuda_buffer_transport():
+    """Validate five Python-created CUDA buffers between rclpy processes."""
+    topic = f'cuda_buffer_py_{uuid.uuid4().hex}'
+    subscriber_source = textwrap.dedent(f"""
+        import time
+
+        from cuda_buffer import CudaBuffer
+        import rclpy
+        from rclpy.node import Node
+        from rosidl_buffer import Buffer
+        from sensor_msgs.msg import Image
+
+        EXPECTED_PAYLOAD = bytes((index * 13 + 7) % 256 for index in range(64))
+
+        rclpy.init()
+        node = Node('cuda_buffer_py_multiprocess_sub')
+        received = []
+
+        def callback(msg):
+            if not isinstance(msg.data, Buffer):
+                received.append(False)
+                print(f'VALIDATION_{{len(received)}}_FAIL_NOT_BUFFER')
+                return
+            if msg.data.backend_type != 'cuda':
+                received.append(False)
+                print(f'VALIDATION_{{len(received)}}_FAIL_BACKEND_{{msg.data.backend_type}}')
+                return
+
+            with CudaBuffer.from_input_buffer(msg.data) as handle:
+                assert handle.device_ptr != 0
+
+            valid = msg.data.to_bytes() == EXPECTED_PAYLOAD
+            received.append(valid)
+            result = 'PASS' if valid else 'FAIL_PAYLOAD'
+            print(f'VALIDATION_{{len(received)}}_{{result}}')
+
+        subscription = node.create_subscription(
+            Image,
+            '{topic}',
+            callback,
+            10,
+            acceptable_buffer_backends='cuda',
+        )
+        deadline = time.monotonic() + 12.0
+        while len(received) < 5 and time.monotonic() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.1)
+        assert len(received) >= 5, (
+            f'subscriber validated only {{len(received)}} of 5 messages'
+        )
+        assert all(received), 'one or more CUDA payload validations failed'
+        node.destroy_subscription(subscription)
+        node.destroy_node()
+        rclpy.shutdown()
+        print('SUBSCRIBER_CUDA_OK')
+    """)
+    publisher_source = textwrap.dedent(f"""
+        import time
+
+        from cuda_buffer import CudaBuffer
+        import rclpy
+        from rclpy.node import Node
+        from sensor_msgs.msg import Image
+
+        EXPECTED_PAYLOAD = bytes((index * 13 + 7) % 256 for index in range(64))
+
+        rclpy.init()
+        node = Node('cuda_buffer_py_multiprocess_pub')
+        publisher = node.create_publisher(Image, '{topic}', 10)
+        deadline = time.monotonic() + 8.0
+        while publisher.get_subscription_count() < 1 and time.monotonic() < deadline:
+            rclpy.spin_once(node, timeout_sec=0.1)
+        assert publisher.get_subscription_count() == 1, 'publisher discovery timed out'
+        time.sleep(1.0)
+
+        msg = Image()
+        msg.height = 1
+        msg.width = 64
+        msg.encoding = '8UC1'
+        msg.step = 64
+        msg.data = CudaBuffer.from_cpu(EXPECTED_PAYLOAD)
+
+        for _ in range(5):
+            publisher.publish(msg)
+            time.sleep(0.1)
+
+        node.destroy_publisher(publisher)
+        node.destroy_node()
+        rclpy.shutdown()
+        print('PUBLISHER_CUDA_OK')
+    """)
+
+    environment = os.environ.copy()
+    environment['ROS_LOCALHOST_ONLY'] = '1'
+    subscriber = subprocess.Popen(
+        [sys.executable, '-c', subscriber_source],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    time.sleep(0.5)
+    publisher = subprocess.Popen(
+        [sys.executable, '-c', publisher_source],
+        env=environment,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+
+    try:
+        publisher_output, _ = publisher.communicate(timeout=15)
+        subscriber_output, _ = subscriber.communicate(timeout=15)
+    finally:
+        if publisher.poll() is None:
+            publisher.terminate()
+            publisher.wait(timeout=5)
+        if subscriber.poll() is None:
+            subscriber.terminate()
+            subscriber.wait(timeout=5)
+
+    assert publisher.returncode == 0, publisher_output
+    assert subscriber.returncode == 0, subscriber_output
+    assert 'PUBLISHER_CUDA_OK' in publisher_output
+    assert 'SUBSCRIBER_CUDA_OK' in subscriber_output
+    for validation_index in range(1, 6):
+        assert f'VALIDATION_{validation_index}_PASS' in subscriber_output
+    assert 'cudaEventSynchronize on the publish path' not in publisher_output


### PR DESCRIPTION
## Description

  This PR adds Python bindings for the CUDA buffer backend, enabling `rclpy` publishers and subscribers to exchange CUDA-backed ROS message fields without converting them to CPU memory.
                                                                                                      
  The new `cuda_buffer_py` package exposes CUDA allocation and scoped read/write APIs that follow the existing C++ buffer lifecycle model.

  ## Python API

  The package adds:                                                                                                                                                                                         

  - `CudaBuffer.from_cpu(data)` — copy CPU data into a CUDA-backed buffer.
  - `CudaBuffer.from_size(size)` — create a zero-initialized CUDA-backed buffer.
  - `CudaBuffer.allocate_buffer(size)` — allocate uninitialized CUDA storage without synchronization.
  - `CudaBuffer.from_output_buffer(buffer, stream)` — acquire a `CudaWriteHandle`.
  - `CudaBuffer.from_input_buffer(buffer, stream)` — acquire a `CudaReadHandle`.
                                                                                                      
  `CudaReadHandle` and `CudaWriteHandle` are context managers that expose the CUDA device pointer through `device_ptr` and `get_ptr()`.
                                                                                                                                                                                                            
  Python type stubs and a `py.typed` marker are included.

  ## Synchronization and lifecycle
                                                   
  The scoped Python handles preserve the synchronization and lifetime guarantees of the C++ implementation:
                                                                                                      
  - Closing a write handle records producer completion on the supplied CUDA stream.
  - Acquiring a read handle waits for the producer event on the consumer stream.
  - Closing a read handle records consumer completion before the allocation can be recycled.
  - Handles retain ownership of the underlying or promoted buffer for the required lifetime.
  - CUDA-backed input remains on the GPU without CPU conversion.
  - CUDA-to-CUDA synchronization uses stream-ordered CUDA events without synchronizing the producer or consumer stream.

  CPU-backed inputs can still be promoted to CUDA automatically. The `from_cpu()` and `from_size()` convenience APIs synchronize initialization before returning, while `allocate_buffer()` and the scoped-
  handle path support asynchronous device-only workflows.

  The bindings use the process-wide CUDA allocation pool provided by the installed `cuda_buffer` shared library. This allows the Python extension and dynamically loaded serialization backend to resolve
  the same CUDA allocations during descriptor creation.

  ## rclpy usage

  Publishers can allocate and populate message fields directly on the GPU:

  ```python
  msg.data = CudaBuffer.allocate_buffer(size)

  with CudaBuffer.from_output_buffer(msg.data, stream_ptr) as handle:
      produce_device_data(handle.device_ptr, size, stream_ptr)

  publisher.publish(msg)

  Subscribers opt into the CUDA backend and consume the device pointer directly:

  subscription = node.create_subscription(
      Image,
      'image',
      callback,
      10,
      acceptable_buffer_backends='cuda',
  )

  def callback(msg):
      with CudaBuffer.from_input_buffer(msg.data, stream_ptr) as handle:
          consume_device_data(handle.device_ptr, len(msg.data), stream_ptr)
```

  ## Testing

  The package includes unit tests for allocation, conversion, scoped handles, synchronization, error handling, and lifetime management.

  It also includes a Fast RTPS multiprocess regression test that:

  - Runs the Python publisher and subscriber in separate OS processes.
  - Uses regular DDS inter-process transport.
  - Publishes five CUDA-backed messages with known payloads.
  - Checks that each received field reports the cuda backend before creating a read handle.
  - Copies the final data to host and validates every payload.
  - Fails if the backend falls back to CPU, payload validation fails, or fewer than five explicit validations are observed.
