### PR TITLE
Build the CUDA buffer backend against CUDA 13

### DIFF
--- a/cuda_buffer_backend/cuda_buffer/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer/CMakeLists.txt
@@ -15,23 +15,21 @@ find_package(cuda_buffer_backend_msgs REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rcutils REQUIRED)
 
-# Workaround for CMake's FindCUDAToolkit on Ubuntu's split nvidia-cuda-dev
-# layout in the bloom build pipeline. Pre-populate the cache variable to
-# skip the broken auto-detection.
-# Related: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995122
-find_path(_CUDA_RUNTIME_DIR
-  NAMES cuda_runtime.h
-  HINTS
-    ENV CUDA_HOME
-    ENV CUDA_PATH
-    /usr/local/cuda/include
-    /usr/include
-)
-if(_CUDA_RUNTIME_DIR AND NOT DEFINED CUDAToolkit_INCLUDE_DIRECTORIES)
-  set(CUDAToolkit_INCLUDE_DIRECTORIES "${_CUDA_RUNTIME_DIR}" CACHE PATH
-    "CUDA include dir (FindCUDAToolkit nvidia-cuda-dev workaround)")
+# CUDA 13 only. Consumers of this backend build against CUDA 13, and a
+# cuda_buffer linked against CUDA 12 pulls a second CUDA runtime into every
+# process that loads the backend. FindCUDAToolkit treats a requested version as
+# a minimum and does not handle version ranges (no HANDLE_VERSION_RANGE on its
+# find_package_handle_standard_args call), so the upper bound is checked here.
+#
+# This requires the NVIDIA cuda-toolkit-13 packages, which install a complete
+# toolkit under /usr/local/cuda-13.x. It deliberately does not fall back to
+# Ubuntu's split nvidia-cuda-toolkit layout: that ships CUDA 12.x on Noble and
+# was what previously got picked up in the bloom build pipeline.
+find_package(CUDAToolkit 13 REQUIRED)
+if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 14)
+  message(FATAL_ERROR
+    "cuda_buffer requires CUDA 13.x; found ${CUDAToolkit_VERSION}")
 endif()
-find_package(CUDAToolkit REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/cuda_buffer.cpp

--- a/cuda_buffer_backend/cuda_buffer/package.xml
+++ b/cuda_buffer_backend/cuda_buffer/package.xml
@@ -14,7 +14,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>cuda_buffer_backend_msgs</depend>
-  <depend>nvidia-cuda</depend>
+  <depend>nvidia-cuda-13</depend>
   <depend>rcutils</depend>
   <depend>rmw</depend>
   <depend>rosidl_buffer</depend>

--- a/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
@@ -12,23 +12,15 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-# Workaround for CMake's FindCUDAToolkit on Ubuntu's split nvidia-cuda-dev
-# layout in the bloom build pipeline. Pre-populate the cache variable to
-# skip the broken auto-detection.
-# Related: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995122
-find_path(_CUDA_RUNTIME_DIR
-  NAMES cuda_runtime.h
-  HINTS
-    ENV CUDA_HOME
-    ENV CUDA_PATH
-    /usr/local/cuda/include
-    /usr/include
-)
-if(_CUDA_RUNTIME_DIR AND NOT DEFINED CUDAToolkit_INCLUDE_DIRECTORIES)
-  set(CUDAToolkit_INCLUDE_DIRECTORIES "${_CUDA_RUNTIME_DIR}" CACHE PATH
-    "CUDA include dir (FindCUDAToolkit nvidia-cuda-dev workaround)")
+# CUDA 13 only, matching cuda_buffer. This target links CUDA directly, so the
+# constraint has to be repeated here; without it the backend can be built
+# against a different toolkit than the library it wraps. See the comment in
+# cuda_buffer/CMakeLists.txt for why the bound is checked rather than requested.
+find_package(CUDAToolkit 13 REQUIRED)
+if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL 14)
+  message(FATAL_ERROR
+    "cuda_buffer_backend requires CUDA 13.x; found ${CUDAToolkit_VERSION}")
 endif()
-find_package(CUDAToolkit REQUIRED)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/cuda_buffer_backend_plugin.cpp

--- a/cuda_buffer_backend/cuda_buffer_backend/package.xml
+++ b/cuda_buffer_backend/cuda_buffer_backend/package.xml
@@ -14,6 +14,7 @@
 
   <depend>cuda_buffer</depend>
   <depend>cuda_buffer_backend_msgs</depend>
+  <depend>nvidia-cuda-13</depend>
   <depend>pluginlib</depend>
   <depend>rcutils</depend>
   <depend>rosidl_buffer_backend</depend>


### PR DESCRIPTION
The published ros-lyrical-cuda-buffer{,-backend} 0.1.2 debs depend on libcudart12 and nvidia-cuda-toolkit, i.e. Ubuntu Noble's distro CUDA toolkit, which is 12.x. Consumers such as the Isaac ROS workspace build against CUDA 13.2, so loading the backend brings a second CUDA runtime into the process.

The toolkit was selected by a workaround that pre-seeded CUDAToolkit_INCLUDE_DIRECTORIES from a find_path hinting /usr/include, matching Ubuntu's split nvidia-cuda-dev layout. That only set include directories, so headers and the CUDA:: imported libraries could come from different toolkits with no error. Drop it: the NVIDIA cuda-toolkit-13 packages install a complete toolkit under /usr/local/cuda-13.x, which FindCUDAToolkit locates on its own, since it puts /usr/local/cuda at the front of its search paths.

Depend on the nvidia-cuda-13 rosdep key so the build environment gets that toolkit, and require CUDA 13 in CMake so a fallback to 12.x fails the build rather than silently producing a mismatched library. FindCUDAToolkit treats a requested version as a minimum and does not opt into CMake's version-range handling, so the upper bound is a separate check; without it CUDA 14 would satisfy find_package(CUDAToolkit 13).

cuda_buffer_backend gets the same treatment: it links CUDA::cudart and CUDA::cuda_driver itself, and its deb has the same libcudart12 dependency, so constraining cuda_buffer alone would not have been enough.

## Description

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Fixes # (issue)

### Is this user-facing behavior change?

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
