### PR TITLE
Improve CUDA event lifecycle and cross-container IPC

### DIFF
--- a/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer.hpp
+++ b/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer.hpp
@@ -103,6 +103,7 @@ public:
 private:
   class BufferRecycler;
 
+  void reap_completed_read_events() const;
   void finalize_write_handle_locked() const;
   static void default_cuda_free(uint8_t * p);
 

--- a/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_handle.hpp
+++ b/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_handle.hpp
@@ -31,8 +31,10 @@ namespace cuda_buffer_backend
 
 class CudaBuffer;
 
-constexpr unsigned int CUDA_BUFFER_EVENT_FLAGS =
-  cudaEventBlockingSync | cudaEventDisableTiming | cudaEventInterprocess;
+constexpr unsigned int CUDA_BUFFER_MINIMUM_EVENT_FLAGS =
+  cudaEventBlockingSync | cudaEventDisableTiming;
+constexpr unsigned int CUDA_BUFFER_DEFAULT_EVENT_FLAGS =
+  CUDA_BUFFER_MINIMUM_EVENT_FLAGS | cudaEventInterprocess;
 
 inline bool cuda_is_stream_usable(cudaStream_t s)
 {
@@ -124,7 +126,7 @@ private:
 
     cudaEvent_t ev{nullptr};
     CUDA_CHECK_NOTHROW(
-      cudaEventCreateWithFlags(&ev, CUDA_BUFFER_EVENT_FLAGS),
+      cudaEventCreateWithFlags(&ev, CUDA_BUFFER_DEFAULT_EVENT_FLAGS),
       return);
     CUDA_CHECK_NOTHROW(cudaEventRecord(ev, stream_), {cudaEventDestroy(ev); return;});
     std::lock_guard<std::mutex> lg(*events_mutex_);

--- a/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_handle.hpp
+++ b/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_handle.hpp
@@ -31,7 +31,8 @@ namespace cuda_buffer_backend
 
 class CudaBuffer;
 
-constexpr unsigned int CUDA_BUFFER_EVENT_FLAGS = cudaEventDisableTiming | cudaEventInterprocess;
+constexpr unsigned int CUDA_BUFFER_EVENT_FLAGS =
+  cudaEventBlockingSync | cudaEventDisableTiming | cudaEventInterprocess;
 
 inline bool cuda_is_stream_usable(cudaStream_t s)
 {

--- a/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_impl.hpp
+++ b/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_impl.hpp
@@ -190,7 +190,8 @@ private:
     cudaError_t ev_err = cudaEventCreateWithFlags(&ev, CUDA_BUFFER_EVENT_FLAGS);
     if (ev_err != cudaSuccess) {
       (void)cudaGetLastError();
-      ev_err = cudaEventCreateWithFlags(&ev, cudaEventDisableTiming);
+      ev_err = cudaEventCreateWithFlags(
+        &ev, cudaEventBlockingSync | cudaEventDisableTiming);
       if (ev_err != cudaSuccess) {
         ev = nullptr;
         (void)cudaGetLastError();

--- a/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_impl.hpp
+++ b/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_impl.hpp
@@ -187,16 +187,21 @@ private:
     VmmBlock * block = pool->allocate(byte_size);
 
     cudaEvent_t ev = nullptr;
-    cudaError_t ev_err = cudaEventCreateWithFlags(&ev, CUDA_BUFFER_EVENT_FLAGS);
+    cudaError_t ev_err = cudaEventCreateWithFlags(&ev, CUDA_BUFFER_DEFAULT_EVENT_FLAGS);
     if (ev_err != cudaSuccess) {
+      const cudaError_t interprocess_event_error = ev_err;
       (void)cudaGetLastError();
-      ev_err = cudaEventCreateWithFlags(
-        &ev, cudaEventBlockingSync | cudaEventDisableTiming);
+      ev_err = cudaEventCreateWithFlags(&ev, CUDA_BUFFER_MINIMUM_EVENT_FLAGS);
       if (ev_err != cudaSuccess) {
         ev = nullptr;
         (void)cudaGetLastError();
         RCUTILS_LOG_WARN_NAMED("cuda_buffer_backend",
           "Failed to create CUDA event; stream ordering disabled for this buffer");
+      } else {
+        RCUTILS_LOG_WARN_ONCE_NAMED(
+          "cuda_buffer_backend",
+          "Failed to create interprocess CUDA event (%s); falling back to a local event",
+          cudaGetErrorName(interprocess_event_error));
       }
     }
 

--- a/cuda_buffer_backend/cuda_buffer/src/cuda_buffer.cpp
+++ b/cuda_buffer_backend/cuda_buffer/src/cuda_buffer.cpp
@@ -137,6 +137,8 @@ CudaBuffer::~CudaBuffer()
 
 ReadHandle CudaBuffer::get_read_handle(cudaStream_t stream) const
 {
+  reap_completed_read_events();
+
   if (handle_state_) {
     std::lock_guard<std::mutex> lk(handle_state_->mtx);
     if (handle_state_->state == HandleState::State::InUse) {
@@ -150,6 +152,7 @@ ReadHandle CudaBuffer::get_read_handle(cudaStream_t stream) const
 
 WriteHandle CudaBuffer::get_write_handle(cudaStream_t stream)
 {
+  reap_completed_read_events();
   std::lock_guard<std::mutex> lg(events_mutex_);
 
   if (handle_state_) {
@@ -170,6 +173,26 @@ WriteHandle CudaBuffer::get_write_handle(cudaStream_t stream)
   handle_state_->state = HandleState::State::InUse;
   handle_state_->write_stream = stream;
   return WriteHandle(device_ptr_.get(), &write_event_, stream, handle_state_);
+}
+
+void CudaBuffer::reap_completed_read_events() const
+{
+  std::lock_guard<std::mutex> lock(events_mutex_);
+  auto event = read_events_.begin();
+  while (event != read_events_.end()) {
+    const cudaError_t status = cudaEventQuery(*event);
+    if (status == cudaSuccess) {
+      CUDA_CHECK_NOTHROW(cudaEventDestroy(*event), (void)0);
+      event = read_events_.erase(event);
+      continue;
+    }
+    if (status != cudaErrorNotReady) {
+      RCUTILS_LOG_WARN_NAMED(
+        "cuda_buffer_backend", "cudaEventQuery failed: %s", cudaGetErrorName(status));
+    }
+    (void)cudaGetLastError();
+    ++event;
+  }
 }
 
 void CudaBuffer::finalize_write_handle() const

--- a/cuda_buffer_backend/cuda_buffer/src/cuda_buffer_ipc_manager.cpp
+++ b/cuda_buffer_backend/cuda_buffer/src/cuda_buffer_ipc_manager.cpp
@@ -26,6 +26,7 @@
 
 #include <atomic>
 #include <cerrno>
+#include <cstddef>
 #include <cstring>
 #include <sstream>
 #include <thread>
@@ -55,13 +56,24 @@ void check_uid_staleness(
   }
 }
 
-struct sockaddr_un make_unix_addr(const std::string & path)
+struct UnixAddress
 {
   struct sockaddr_un addr;
-  memset(&addr, 0, sizeof(addr));
-  addr.sun_family = AF_UNIX;
-  strncpy(addr.sun_path, path.c_str(), sizeof(addr.sun_path) - 1);
-  return addr;
+  socklen_t length;
+};
+
+UnixAddress make_abstract_unix_addr(const std::string & name)
+{
+  UnixAddress address{};
+  if (name.empty() || name.size() > sizeof(address.addr.sun_path) - 1) {
+    throw CudaError("Invalid abstract Unix socket name");
+  }
+
+  address.addr.sun_family = AF_UNIX;
+  memcpy(address.addr.sun_path + 1, name.data(), name.size());
+  address.length = static_cast<socklen_t>(
+    offsetof(sockaddr_un, sun_path) + 1 + name.size());
+  return address;
 }
 
 }  // namespace
@@ -392,7 +404,6 @@ CudaVmmIPCManager::~CudaVmmIPCManager()
   for (auto & [id, info] : registered_blocks_) {
     if (info.server_socket >= 0 && dispatcher_) {
       dispatcher_->remove_socket(info.server_socket);
-      unlink(info.socket_path.c_str());
     }
   }
   registered_blocks_.clear();
@@ -408,7 +419,7 @@ std::string CudaVmmIPCManager::register_block(VmmBlock * block)
   }
 
   std::stringstream ss;
-  ss << "/tmp/cuda_vmm_" << getpid() << "_" << block->block_id << ".sock";
+  ss << "cuda_vmm_" << getpid() << "_" << block->block_id;
   std::string socket_path = ss.str();
 
   int server_socket = create_fd_server_socket(socket_path);
@@ -559,22 +570,21 @@ CudaVmmIPCManager::ImportResult CudaVmmIPCManager::import_block(
 
 int CudaVmmIPCManager::create_fd_server_socket(const std::string & socket_path)
 {
-  unlink(socket_path.c_str());
-
   int server_socket = socket(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0);
   if (server_socket < 0) {
     return -1;
   }
 
-  auto addr = make_unix_addr(socket_path);
-  if (bind(server_socket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+  auto address = make_abstract_unix_addr(socket_path);
+  if (bind(
+      server_socket, reinterpret_cast<struct sockaddr *>(&address.addr), address.length) < 0)
+  {
     close(server_socket);
     return -1;
   }
 
   if (listen(server_socket, 5) < 0) {
     close(server_socket);
-    unlink(socket_path.c_str());
     return -1;
   }
 
@@ -588,8 +598,10 @@ int CudaVmmIPCManager::receive_fd_from_socket(const std::string & socket_path)
     return -1;
   }
 
-  auto addr = make_unix_addr(socket_path);
-  if (connect(client_socket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+  auto address = make_abstract_unix_addr(socket_path);
+  if (connect(
+      client_socket, reinterpret_cast<struct sockaddr *>(&address.addr), address.length) < 0)
+  {
     close(client_socket);
     return -1;
   }


### PR DESCRIPTION
Reap completed read events, reduce synchronization CPU usage, and replace filesystem sockets with abstract Unix sockets.

## Description

CUDA read events previously remained allocated until the associated buffer was destroyed. Reused buffers could therefore accumulate completed events and eventually exhaust CUDA event resources, causing `cudaEventCreateWithFlags()` to fail with `cudaErrorMemoryAllocation`.

This change:

- Queries and destroys completed read events when a buffer is reused.
- Retains incomplete events to preserve stream synchronization.
- Uses `cudaEventBlockingSync` to reduce CPU usage while synchronizing.
- Replaces filesystem-backed Unix sockets with abstract Unix sockets, enabling CUDA VMM IPC across containers without requiring a shared filesystem path.

### Is this user-facing behavior change?

There are no public API changes.

### Did you use Generative AI?

Cursor with GPT-5.6 Sol was used