### PR TITLE
Add qualcomm implement for rosidl_buffer_backend

### DIFF
--- a/qc_buffer_backend/README.md
+++ b/qc_buffer_backend/README.md
@@ -1,0 +1,83 @@
+# qc_buffer_backend
+
+A `rosidl::Buffer<T>` storage backend for Qualcomm platforms that delivers message payloads with **HTP–CPU zero-copy** in ROS2 pipeline.
+
+Payloads are allocated in Qualcomm dma-buf memory. This memory is directly readable/writable by the CPU and, through its dma-buf fd, can be shared with the HTP(Qualcomm NPU) accelerator so it reads the exact same physical pages — no copy. When zero-copy is not possible (cross-device, or not QC device), the backend transparently falls back to the default CPU serialization path, so functionality is always correct.
+
+The QC backend has no compile-time dependency on any Qualcomm SDK. The only dependency is `libcdsprpc.so`, and it is resolved entirely at runtime via dlopen. This means the package can be built on any standard Linux host without any Qualcomm-specific toolchain installed. On Qualcomm platforms, libcdsprpc.so ships as part of the board support package and is available by default on virtually all Qualcomm Linux targets, so no additional installation step is required at runtime either.
+
+## Layout
+
+```
+qc_buffer_backend/
+├── qc_buffer/               Core library (no accelerator SDK dependency)
+│   ├── include/qc_buffer/
+│   │   ├── rpcmem_loader.hpp           dlopen(libcdsprpc.so) + rpcmem_* symbols
+│   │   ├── qc_buffer.hpp               RAII holder for one ION/dma-buf allocation
+│   │   ├── qc_buffer_impl.hpp          rosidl::BufferImplBase<uint8_t> implementation
+│   │   ├── qc_buffer_api.hpp           user API: allocate_buffer / get_data_ptr / get_dmabuf_fd
+│   │   ├── fd_broker.hpp               per-publisher fd broker (SCM_RIGHTS delivery)
+│   │   ├── intra_process_registry.hpp  uid -> shared_ptr<QcBuffer> table (retained for testing)
+│   │   ├── qc_error.hpp                exception type
+│   │   └── visibility_control.h
+│   └── src/                            implementations of the above
+├── qc_buffer_backend/                  pluginlib backend plugin (rosidl::BufferBackend)
+│   ├── include/qc_buffer_backend/qc_buffer_backend.hpp
+│   ├── src/qc_buffer_backend_plugin.cpp
+│   └── qc_buffer_plugin.xml            plugin description registered with pluginlib
+├── qc_buffer_backend_msgs/             QcBufferDescriptor.msg (published during serialization)
+├── docs/                               design document
+└── tutorial/                           minimal publisher/subscriber example (see tutorial/README.md)
+```
+
+## Using it in a publisher
+
+Allocate a qc-backed buffer, write into it through the CPU pointer, and publish as usual. No handles or streams are needed — the memory is plain CPU memory.
+
+```cpp
+#include "qc_buffer/qc_buffer_api.hpp"
+
+sensor_msgs::msg::Image msg;
+msg.data = qc_buffer_backend::allocate_buffer(width * height * 3);
+// ... set msg.width / height / encoding / step ...
+
+uint8_t * p = qc_buffer_backend::get_data_ptr(msg.data);   // CPU pointer into ION memory
+// ... fill p[0 .. size) ...
+
+publisher_->publish(msg);
+```
+
+`allocate_buffer()` throws `qc_buffer_backend::QcError` if an explicit qc allocation fails. On a device without `libcdsprpc.so`, prefer writing through the normal `msg.data[i]` accessor so the code also works on the CPU fallback path (see the tutorial publisher for both branches).
+
+## Using it in a subscriber
+
+Accept any backend, then branch on `get_backend_type()`. When it is `"qc"` the payload is the same memory the publisher wrote (zero-copy); read it directly and/or hand its dma-buf fd to the HTP.
+
+```cpp
+#include "qc_buffer/qc_buffer_api.hpp"
+
+rclcpp::SubscriptionOptions sub_opts;
+sub_opts.acceptable_buffer_backends = "any";   // accept qc or cpu
+subscription_ = create_subscription<sensor_msgs::msg::Image>(
+  "qc_image", 10, callback, sub_opts);
+
+// in the callback:
+if (msg->data.get_backend_type() == "qc") {
+  int fd = qc_buffer_backend::get_dmabuf_fd(msg->data);   // pass to the HTP accelerator
+  uint8_t * p = qc_buffer_backend::get_data_ptr(msg->data);  // CPU read, no copy
+  // ... use p / fd ...
+} else {
+  const std::vector<uint8_t> & data = msg->data;   // CPU fallback
+  // ... use data ...
+}
+```
+
+The backend is loaded by `pluginlib` at runtime; the subscriber only needs `acceptable_buffer_backends = "any"` (or `"qc"`) to receive qc-backed messages.
+
+## Build
+
+```bash
+colcon build --packages-select qc_buffer_backend_msgs qc_buffer qc_buffer_backend
+```
+
+See `docs/qc_buffer_backend_design.md` for the design and `tutorial/README.md` for a runnable end-to-end example.

--- a/qc_buffer_backend/docs/qc_buffer_backend_design.md
+++ b/qc_buffer_backend/docs/qc_buffer_backend_design.md
@@ -1,0 +1,256 @@
+# Design
+
+## Introduction
+
+`qc_buffer_backend` is a `rosidl::Buffer<T>` storage backend that allocates the message payload in Qualcomm ION / dma-buf memory and delivers it to a subscriber **without serialization or host copies** when the runtime conditions allow it. When they don't, the system falls back to the default CPU path automatically.
+
+The optimized path is taken when the publisher and subscriber are on the **same device**. The ION buffer is CPU-accessible and, through its dma-buf fd, can be shared with the HTP (Qualcomm NPU) accelerator so it reads the exact same physical pages the CPU wrote — this is what makes HTP-CPU zero-copy possible. Both same-process and cross-process subscribers on the same device are supported.
+
+## Class diagram
+
+Classes are grouped by origin. **ROS2 framework classes** (from `rosidl` / `rosidl_buffer`) are shown in the `rosidl` package. **`qc_buffer_backend` classes** (implemented in this repository) are shown in the `qc_buffer_backend` package.
+
+```mermaid
+classDiagram
+    direction TB
+
+    namespace rosidl {
+        class BufferBackend {
+            <<interface, rosidl_buffer_backend>>
+            +get_backend_type() string
+            +create_descriptor_with_endpoint(impl, endpoint) shared_ptr
+            +from_descriptor_with_endpoint(desc, endpoint) unique_ptr
+        }
+
+        class Buffer_T {
+            <<rosidl_buffer>>
+            +get_backend_type() string
+            +size() size_t
+            +get_impl() BufferImplBase_T*
+        }
+
+        class BufferImplBase_T {
+            <<interface, rosidl_buffer>>
+            +get_backend_type() string
+            +size() size_t
+            +to_cpu() unique_ptr
+            +clone() unique_ptr
+        }
+    }
+
+    namespace qc_buffer_backend {
+        class QcBufferBackend {
+            <<qc_buffer_backend>>
+            +get_backend_type() string
+            +create_descriptor_with_endpoint(impl, endpoint) shared_ptr
+            +from_descriptor_with_endpoint(desc, endpoint) unique_ptr
+        }
+
+        class QcBufferImpl_T {
+            <<qc_buffer>>
+            -size_ size_t
+            -qc_buffer_ shared_ptr~QcBuffer~
+            +get_backend_type() string
+            +size() size_t
+            +to_cpu() unique_ptr
+            +clone() unique_ptr
+            +get_qc_buffer() shared_ptr~QcBuffer~
+        }
+
+        class QcBuffer {
+            <<qc_buffer>>
+            -ptr_ uint8_t*
+            -fd_ int
+            -size_ size_t
+            -uid_ uint64_t
+            -origin_ Origin
+            +data() uint8_t*
+            +dmabuf_fd() int
+            +size() size_t
+            +uid() uint64_t
+        }
+
+        class FdBroker {
+            <<qc_buffer>>
+            -table_ unordered_map
+            -order_ deque
+            -server_fd_ int
+            -socket_path_ string
+            -running_ atomic~bool~
+            -active_connections_ atomic~int~
+            +instance()$ FdBroker&
+            +register_buffer(uid, fd, size)
+            +socket_path() string
+            +running() bool
+        }
+
+        class RpcMemLoader {
+            <<qc_buffer>>
+            -available_ bool
+            -lib_ void*
+            +instance()$ RpcMemLoader&
+            +available() bool
+            +alloc(heap_id, flags, size) void*
+            +free(ptr)
+            +to_fd(ptr) int
+        }
+
+        class QcBufferDescriptor {
+            <<qc_buffer_backend_msgs>>
+            +uid uint64_t
+            +pid int32_t
+            +size uint64_t
+            +dmabuf_size uint64_t
+            +dmabuf_fd int32_t
+            +vaddr uint64_t
+            +use_ipc bool
+            +ipc_socket_path string
+            +element_type_name string
+        }
+    }
+
+    BufferBackend <|.. QcBufferBackend : implements
+    BufferImplBase_T <|.. QcBufferImpl_T : implements
+    Buffer_T o-- BufferImplBase_T : holds pimpl
+    QcBufferImpl_T *-- QcBuffer : owns
+    QcBufferBackend ..> QcBufferImpl_T : creates / inspects
+    QcBufferBackend ..> FdBroker : register_buffer
+    QcBufferBackend ..> RpcMemLoader : available()
+    QcBufferBackend ..> QcBufferDescriptor : creates / reads
+    QcBuffer ..> RpcMemLoader : alloc/free (kRpcmem)
+```
+
+## Class descriptions of `qc_buffer_backend`
+
+These classes are implemented in folder `qc_buffer_backend`. They are split across three ROS2 packages: `qc_buffer` (core library), `qc_buffer_backend` (plugin), and `qc_buffer_backend_msgs` (message definition).
+
+#### `QcBufferBackend` — `qc_buffer_backend` package
+
+The pluginlib plugin entry point. On the publish path, `create_descriptor_with_endpoint()` extracts the dma-buf fd from the `QcBufferImpl`, registers it with `FdBroker`, and fills a `QcBufferDescriptor`. On the subscribe path, `from_descriptor_with_endpoint()` connects to the publisher's broker socket, receives a fd via `SCM_RIGHTS`, calls `mmap()`, and constructs a new `QcBufferImpl`. Any failure returns an empty impl, triggering a DDS CPU fallback.
+
+#### `QcBufferImpl<T>` — `qc_buffer` package
+
+The Qualcomm implementation of `BufferImplBase<T>`, holding a `shared_ptr<QcBuffer>`. Three construction paths:
+- **Default**: empty impl (size 0, no allocation).
+- **By size**: publisher path — calls `rpcmem_alloc` via `QcBuffer(byte_size)`.
+- **By fd**: subscriber path — calls `mmap(fd)` and wraps the result in `QcBuffer(ptr, size, fd)`.
+
+Destruction delegates to `QcBuffer::reset()`, which calls either `rpcmem_free` or `munmap + close(fd)` depending on the `Origin` tag.
+
+#### `QcBuffer` — `qc_buffer` package
+
+RAII owner of a single ION / dma-buf allocation. Non-copyable. Two origin variants:
+- **kRpcmem**: allocated by the publisher via `rpcmem_alloc`; `reset()` calls `rpcmem_free`.
+- **kMmap**: mapped by the subscriber via `mmap(fd)`; `reset()` calls `munmap + close(fd)`.
+
+`uid()` is a process-monotonic identifier used by `FdBroker` for fd lookup. `dmabuf_fd()` is the kernel fd passed to the HTP accelerator for zero-copy access.
+
+#### `FdBroker` — `qc_buffer` package
+
+A process-level singleton Unix socket server in the publisher process. `register_buffer()` calls `dup(fd)` on each newly published buffer's dma-buf fd, keeping the kernel dma-buf object alive after `QcBuffer` destructs. Any subscriber (same or different process on the same device) connects, sends the uid, and receives a fd copy via `sendmsg + SCM_RIGHTS`; the broker then closes its own dup. A rolling FIFO window (64 slots) bounds memory retention. The destructor spins on `active_connections_` to ensure all detached connection threads finish before tearing down internal state.
+
+#### `RpcMemLoader` — `qc_buffer` package
+
+A process-level singleton that `dlopen`s `libcdsprpc.so` and resolves `rpcmem_alloc`, `rpcmem_free`, and `rpcmem_to_fd`. When `available()` returns false (library absent, e.g. on a developer host), the entire backend falls back to the CPU path transparently.
+
+#### `QcBufferDescriptor` — `qc_buffer_backend_msgs` package
+
+The lightweight descriptor transmitted from publisher to subscriber over DDS. Key fields: `uid` for broker lookup, `ipc_socket_path` for the broker Unix socket, `dmabuf_size` for the `mmap()` call, and `use_ipc` to signal whether the FdBroker path is active. The `pid`, `vaddr`, and `dmabuf_fd` fields carry debug information about the publisher-side allocation.
+
+## High-level architecture
+
+```mermaid
+flowchart LR
+  Pub["Publisher node"]
+  Sub["Subscriber node\n(same or different process)"]
+
+  Pub -->|"allocate_buffer + CPU write"| Buffer["rosidl::Buffer&lt;uint8_t&gt;"]
+  Buffer -->|"backend = 'qc'"| Plugin["qc_buffer_backend plugin"]
+  Plugin -->|"create_descriptor"| Descriptor["QcBufferDescriptor\nuse_ipc=true, socket_path, uid, size"]
+  Descriptor -->|"published over RMW"| Sub
+  Plugin -.->|"rpcmem_alloc / free"| Loader["RpcMemLoader"]
+  Plugin -.->|"register_buffer(uid, fd)"| Broker["FdBroker"]
+  Sub -.->|"connect + SCM_RIGHTS"| Broker
+  Sub -.->|"mmap(fd)"| Mem["Same physical pages"]
+  Sub -.->|"get_dmabuf_fd to HTP"| HTP["HTP inference / app layer"]
+```
+
+## Publish / subscribe flow
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant Pub as Publisher
+  participant Broker as FdBroker
+  participant Sub as Subscriber
+  participant App as App layer / HTP
+
+  Pub->>Pub: buf = allocate_buffer(N), rpcmem_alloc returns VA + fd + uid
+  Pub->>Pub: write data to buf via CPU pointer, no copy
+  Pub->>Pub: msg.data = buf, then publish(msg)
+  Pub->>Broker: register_buffer(uid, fd) — broker stores dup(fd)
+  Note over Pub,Sub: descriptor = use_ipc=true, socket_path, uid, dmabuf_size, size
+  Pub->>Pub: QcBuffer destructs, original fd closed, broker's dup keeps dma-buf alive
+  Sub->>Broker: connect(socket_path), send(uid)
+  Broker-->>Sub: SCM_RIGHTS(dup_fd) — subscriber receives new fd
+  Broker->>Broker: close own dup_fd (subscriber holds its own reference)
+  Sub->>Sub: mmap(fd, dmabuf_size) — maps same physical pages, zero-copy
+  Sub->>App: get_dmabuf_fd(buf) returns fd
+  App->>App: register fd with HTP, which reads the same memory
+  Sub->>Sub: QcBufferImpl destructs: munmap + close(fd)
+  Note over Sub: dma-buf refcount reaches 0 only after all subscribers close their fds
+```
+
+The subscriber performs **no memcpy**: its `mmap()`-ed address and the publisher's original `vaddr` point at the same physical pages (zero-copy).
+
+## Fallback decision
+
+The backend never breaks functionality; the worst case is a CPU copy. It falls back (returns `nullptr` / an empty impl, letting the serialization layer use the CPU path) when any of the following holds:
+
+```mermaid
+flowchart TB
+  Create["create_descriptor_with_endpoint(impl)"] --> A{"impl is QcBufferImpl?"}
+  A -->|no| Fallback["CPU fallback"]
+  A -->|yes| B{"RpcMemLoader available?"}
+  B -->|no| Fallback
+  B -->|yes| C{"dma-buf fd valid?"}
+  C -->|no| Fallback
+  C -->|yes| D{"FdBroker running?"}
+  D -->|no| Fallback
+  D -->|yes| Emit["register uid with FdBroker, emit descriptor"]
+
+  From["from_descriptor_with_endpoint(desc)"] --> E{"element type matches?"}
+  E -->|no| Drop["empty impl, CPU"]
+  E -->|yes| F{"use_ipc and socket_path present?"}
+  F -->|no| Drop
+  F -->|yes| G{"broker connect + uid found?"}
+  G -->|no| Drop
+  G -->|yes| H{"mmap(fd) succeeds?"}
+  H -->|no| Drop
+  H -->|yes| Reuse["QcBufferImpl via mmap, zero-copy"]
+```
+
+A **type or contract violation** (e.g. a non-`uint8_t` element type name, or an explicit qc allocation that fails) is treated as an error — allocation throws `QcError`, while `from_descriptor` logs and drops. An **environmental limitation** (no rpcmem, cross-device, broker miss) is a normal expected downgrade and only logs at WARN (once where appropriate).
+
+## Buffer lifetime
+
+```mermaid
+flowchart TD
+  A["rpcmem_alloc creates QcBuffer: VA + fd + uid"] --> B["shared_ptr held by published msg"]
+  B --> C["create_descriptor: FdBroker stores dup(fd)"]
+  C --> D["descriptor published over DDS"]
+  B --> E["QcBuffer destructs: rpcmem_free + close(original fd)"]
+  E --> F["dma-buf kept alive by broker's dup_fd"]
+
+  D --> G["subscriber connects to broker, requests uid"]
+  G --> H{"uid still in broker window?"}
+  H -->|yes| I["broker sends dup_fd via SCM_RIGHTS, closes own copy"]
+  H -->|no| J["MISS — CPU fallback"]
+
+  I --> K["subscriber: mmap(fd) — same physical pages"]
+  K --> L["subscriber callback runs"]
+  L --> M["QcBufferImpl destructs: munmap + close(fd)"]
+  M --> N["dma-buf refcount 0 when all subscribers done — memory freed"]
+```
+
+The `FdBroker` retention window (64 slots, FIFO eviction) bounds how long a buffer's fd is kept available for subscribers. At 30 Hz a window of 64 covers over 2 seconds. A subscriber that arrives after eviction sees a miss and falls back to CPU.

--- a/qc_buffer_backend/qc_buffer/CMakeLists.txt
+++ b/qc_buffer_backend/qc_buffer/CMakeLists.txt
@@ -1,0 +1,75 @@
+cmake_minimum_required(VERSION 3.20)
+project(qc_buffer)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_buffer REQUIRED)
+find_package(qc_buffer_backend_msgs REQUIRED)
+find_package(rmw REQUIRED)
+find_package(rcutils REQUIRED)
+
+add_library(${PROJECT_NAME} SHARED
+  src/rpcmem_loader.cpp
+  src/qc_buffer.cpp
+  src/fd_broker.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+
+target_link_libraries(${PROJECT_NAME}
+  PUBLIC
+    rosidl_buffer::rosidl_buffer
+    rmw::rmw
+    rcutils::rcutils
+    ${qc_buffer_backend_msgs_TARGETS}
+  PRIVATE
+    ${CMAKE_DL_LIBS}
+)
+
+install(
+  DIRECTORY include/
+  DESTINATION include/${PROJECT_NAME}
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include/${PROJECT_NAME}
+)
+
+ament_export_targets(${PROJECT_NAME} HAS_LIBRARY_TARGET)
+ament_export_dependencies(rosidl_buffer qc_buffer_backend_msgs rmw rcutils)
+ament_export_libraries(${PROJECT_NAME})
+ament_export_include_directories(include/${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+
+  ament_add_gtest(test_qc_buffer
+    test/test_qc_buffer.cpp
+  )
+  if(TARGET test_qc_buffer)
+    target_link_libraries(test_qc_buffer
+      ${PROJECT_NAME}
+      rosidl_buffer::rosidl_buffer
+    )
+  endif()
+endif()
+
+ament_package()

--- a/qc_buffer_backend/qc_buffer/CMakeLists.txt
+++ b/qc_buffer_backend/qc_buffer/CMakeLists.txt
@@ -58,6 +58,17 @@ ament_export_include_directories(include/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_qc_buffer
+    test/test_qc_buffer.cpp
+  )
+  if(TARGET test_qc_buffer)
+    target_link_libraries(test_qc_buffer
+      ${PROJECT_NAME}
+      rosidl_buffer::rosidl_buffer
+    )
+  endif()
 endif()
 
 ament_package()

--- a/qc_buffer_backend/qc_buffer/CMakeLists.txt
+++ b/qc_buffer_backend/qc_buffer/CMakeLists.txt
@@ -58,18 +58,6 @@ ament_export_include_directories(include/${PROJECT_NAME})
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-
-  find_package(ament_cmake_gtest REQUIRED)
-
-  ament_add_gtest(test_qc_buffer
-    test/test_qc_buffer.cpp
-  )
-  if(TARGET test_qc_buffer)
-    target_link_libraries(test_qc_buffer
-      ${PROJECT_NAME}
-      rosidl_buffer::rosidl_buffer
-    )
-  endif()
 endif()
 
 ament_package()

--- a/qc_buffer_backend/qc_buffer/include/qc_buffer/fd_broker.hpp
+++ b/qc_buffer_backend/qc_buffer/include/qc_buffer/fd_broker.hpp
@@ -1,0 +1,95 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QC_BUFFER__FD_BROKER_HPP_
+#define QC_BUFFER__FD_BROKER_HPP_
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <string>
+#include <thread>
+#include <unordered_map>
+
+#include "qc_buffer/visibility_control.h"
+
+namespace qc_buffer_backend
+{
+
+/// \brief Per-publisher-process fd broker for cross-process dma-buf sharing.
+///
+/// FdBroker is a process-level singleton. The publisher calls register_buffer()
+/// for each newly published buffer; the broker holds a dup(fd) so the dma-buf
+/// kernel object stays alive even after QcBuffer destructs. Any subscriber
+/// (same process or different process on the same device) connects to the Unix
+/// socket, sends the uid, and receives a new fd via SCM_RIGHTS.
+///
+/// The rolling window (kCapacity entries) bounds retained memory. Once a uid
+/// is evicted, the broker closes its dup_fd; subscribers that have already
+/// taken a copy are unaffected (they hold their own kernel reference).
+class QC_BUFFER_PUBLIC FdBroker
+{
+public:
+  static FdBroker & instance();
+
+  /// Register a newly published buffer. Dups fd and stores it.
+  /// Safe to call multiple times with the same uid (idempotent).
+  void register_buffer(uint64_t uid, int fd, uint64_t dmabuf_size);
+
+  /// Socket path subscribers should connect to.
+  const std::string & socket_path() const {return socket_path_;}
+
+  /// True if the broker is running (socket bound and worker thread live).
+  bool running() const {return running_;}
+
+  /// Number of handle_connection threads currently executing.
+  int active_connections() const
+  {return active_connections_.load(std::memory_order_acquire);}
+
+  ~FdBroker();
+
+private:
+  FdBroker();
+
+  void start();
+  void worker_loop();
+  void handle_connection(int conn_fd);
+
+  struct Entry
+  {
+    int dup_fd;
+    uint64_t dmabuf_size;
+  };
+
+  /// Shared FIFO window across all publishers in this process.
+  static constexpr size_t kCapacity = 64;
+  static constexpr uint8_t kStatusOk = 0x01;
+  static constexpr uint8_t kStatusMiss = 0x02;
+
+  mutable std::mutex mutex_;
+  std::unordered_map<uint64_t, Entry> table_;
+  std::deque<uint64_t> order_;
+
+  int server_fd_{-1};
+  std::string socket_path_;
+  std::thread worker_;
+  std::atomic<bool> running_{false};  // atomic: written by destructor, read by worker
+  std::atomic<int> active_connections_{0};  // destructor spins until 0 before teardown
+};
+
+}  // namespace qc_buffer_backend
+
+#endif  // QC_BUFFER__FD_BROKER_HPP_

--- a/qc_buffer_backend/qc_buffer/include/qc_buffer/qc_buffer.hpp
+++ b/qc_buffer_backend/qc_buffer/include/qc_buffer/qc_buffer.hpp
@@ -1,0 +1,75 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QC_BUFFER__QC_BUFFER_HPP_
+#define QC_BUFFER__QC_BUFFER_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "qc_buffer/visibility_control.h"
+
+namespace qc_buffer_backend
+{
+
+/// \brief Internal RAII holder for a single ION/dma-buf allocation.
+///
+/// Two construction paths:
+///   kRpcmem (default): publisher allocates via rpcmem_alloc; reset() calls
+///                      rpcmem_free.
+///   kMmap: cross-process subscriber receives a dma-buf fd via SCM_RIGHTS and
+///          mmap()s it; reset() calls munmap() + close(fd).
+class QC_BUFFER_PUBLIC QcBuffer
+{
+public:
+  QcBuffer() = default;
+
+  /// Allocate \p byte_size bytes via rpcmem. Throws QcError on failure.
+  explicit QcBuffer(size_t byte_size);
+
+  /// Cross-process subscriber path: adopt an externally mmap-ed pointer and
+  /// the fd it was mapped from. Takes ownership of both (munmap + close on
+  /// destruction). \p uid is assigned by next_uid().
+  QcBuffer(uint8_t * ptr, size_t size, int fd);
+
+  ~QcBuffer();
+
+  QcBuffer(QcBuffer && other) noexcept;
+  QcBuffer & operator=(QcBuffer && other) noexcept;
+
+  QcBuffer(const QcBuffer &) = delete;
+  QcBuffer & operator=(const QcBuffer &) = delete;
+
+  uint8_t * data() {return ptr_;}
+  const uint8_t * data() const {return ptr_;}
+
+  int dmabuf_fd() const {return fd_;}
+  size_t size() const {return size_;}
+  uint64_t uid() const {return uid_;}
+
+private:
+  void reset() noexcept;
+
+  enum class Origin { kRpcmem, kMmap };
+
+  uint8_t * ptr_{nullptr};
+  int fd_{-1};
+  size_t size_{0};
+  uint64_t uid_{0};
+  Origin origin_{Origin::kRpcmem};
+};
+
+}  // namespace qc_buffer_backend
+
+#endif  // QC_BUFFER__QC_BUFFER_HPP_

--- a/qc_buffer_backend/qc_buffer/include/qc_buffer/qc_buffer_api.hpp
+++ b/qc_buffer_backend/qc_buffer/include/qc_buffer/qc_buffer_api.hpp
@@ -1,0 +1,85 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QC_BUFFER__QC_BUFFER_API_HPP_
+#define QC_BUFFER__QC_BUFFER_API_HPP_
+
+#include <cstdint>
+#include <memory>
+#include <utility>
+
+#include "qc_buffer/qc_buffer.hpp"
+#include "qc_buffer/qc_buffer_impl.hpp"
+#include "rosidl_buffer/buffer.hpp"
+
+namespace qc_buffer_backend
+{
+
+/// \brief Allocate a fresh qc-backed rosidl::Buffer<uint8_t> of \p count
+/// bytes. Pure allocation: no data is copied. The caller owns the returned
+/// buffer and assigns it wherever the message schema needs it. Throws
+/// QcError if the rpcmem allocation fails.
+inline rosidl::Buffer<uint8_t> allocate_buffer(size_t count)
+{
+  return rosidl::Buffer<uint8_t>(
+    std::make_unique<QcBufferImpl<uint8_t>>(count));
+}
+
+namespace detail
+{
+
+inline QcBufferImpl<uint8_t> * qc_impl_of(rosidl::Buffer<uint8_t> & buffer)
+{
+  return dynamic_cast<QcBufferImpl<uint8_t> *>(buffer.get_impl());
+}
+
+inline const QcBufferImpl<uint8_t> * qc_impl_of(const rosidl::Buffer<uint8_t> & buffer)
+{
+  return dynamic_cast<const QcBufferImpl<uint8_t> *>(buffer.get_impl());
+}
+
+}  // namespace detail
+
+/// \brief Return the dma-buf fd backing \p buffer, or -1 if the buffer is not
+/// qc-backed (e.g. a CPU buffer) or has no allocation.
+///
+/// This is the integration point for HTP zero-copy: the application passes
+/// this fd to the HTP accelerator so it reads the same physical memory the
+/// CPU wrote, without a copy. The backend itself stays independent of any
+/// accelerator SDK.
+inline int get_dmabuf_fd(const rosidl::Buffer<uint8_t> & buffer)
+{
+  const auto * impl = detail::qc_impl_of(buffer);
+  if (!impl) {
+    return -1;
+  }
+  const auto & qc = impl->get_qc_buffer();
+  return qc ? qc->dmabuf_fd() : -1;
+}
+
+/// \brief Return the CPU-accessible pointer backing \p buffer, or nullptr if
+/// the buffer is not qc-backed. The bytes are directly readable/writable.
+inline uint8_t * get_data_ptr(rosidl::Buffer<uint8_t> & buffer)
+{
+  auto * impl = detail::qc_impl_of(buffer);
+  if (!impl) {
+    return nullptr;
+  }
+  auto & qc = impl->get_qc_buffer();
+  return qc ? qc->data() : nullptr;
+}
+
+}  // namespace qc_buffer_backend
+
+#endif  // QC_BUFFER__QC_BUFFER_API_HPP_

--- a/qc_buffer_backend/qc_buffer/include/qc_buffer/qc_buffer_impl.hpp
+++ b/qc_buffer_backend/qc_buffer/include/qc_buffer/qc_buffer_impl.hpp
@@ -1,0 +1,117 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QC_BUFFER__QC_BUFFER_IMPL_HPP_
+#define QC_BUFFER__QC_BUFFER_IMPL_HPP_
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <cerrno>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <utility>
+
+#include "qc_buffer/qc_buffer.hpp"
+#include "qc_buffer/qc_error.hpp"
+#include "rosidl_buffer/buffer_impl_base.hpp"
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+
+namespace qc_buffer_backend
+{
+
+template<typename T>
+class QcBufferImpl : public rosidl::BufferImplBase<T>
+{
+public:
+  QcBufferImpl()
+  : size_(0) {}
+
+  explicit QcBufferImpl(size_t size)
+  : size_(size)
+  {
+    if (size_ > 0) {
+      qc_buffer_ = std::make_shared<QcBuffer>(size_ * sizeof(T));
+    }
+  }
+
+  /// Adopt an existing QcBuffer (same physical memory, zero-copy).
+  QcBufferImpl(std::shared_ptr<QcBuffer> buffer, size_t size)
+  : size_(size), qc_buffer_(std::move(buffer)) {}
+
+  /// Cross-process subscriber path: mmap a dma-buf fd received via SCM_RIGHTS
+  /// into this process's address space.
+  ///
+  /// Ownership: the caller transfers ownership of \p fd to this constructor.
+  /// On success, fd is owned by the internal QcBuffer (closed on destruction).
+  /// On failure (mmap error), fd is closed before the exception is thrown —
+  /// the caller must not close fd after catching the exception.
+  QcBufferImpl(int fd, size_t dmabuf_size, size_t element_count)
+  : size_(element_count)
+  {
+    void * ptr = ::mmap(nullptr, dmabuf_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    if (ptr == MAP_FAILED) {
+      ::close(fd);
+      throw QcError(
+        "QcBufferImpl: mmap of cross-process dma-buf failed: " +
+        std::string(strerror(errno)));
+    }
+    qc_buffer_ = std::make_shared<QcBuffer>(
+      static_cast<uint8_t *>(ptr), dmabuf_size, fd);
+  }
+
+  ~QcBufferImpl() override = default;
+
+  QcBufferImpl(const QcBufferImpl &) = delete;
+  QcBufferImpl & operator=(const QcBufferImpl &) = delete;
+  QcBufferImpl(QcBufferImpl &&) = delete;
+  QcBufferImpl & operator=(QcBufferImpl &&) = delete;
+
+  std::string get_backend_type() const override {return "qc";}
+  size_t size() const override {return size_;}
+
+  std::unique_ptr<rosidl::BufferImplBase<T>> to_cpu() const override
+  {
+    auto cpu = std::make_unique<rosidl::CpuBufferImpl<T>>();
+    cpu->get_storage().resize(size_);
+    if (size_ > 0 && qc_buffer_ && qc_buffer_->data()) {
+      std::memcpy(cpu->get_storage().data(), qc_buffer_->data(), size_ * sizeof(T));
+    }
+    return cpu;
+  }
+
+  std::unique_ptr<rosidl::BufferImplBase<T>> clone() const override
+  {
+    auto copy = std::make_unique<QcBufferImpl<T>>(size_);
+    if (size_ > 0 && qc_buffer_ && qc_buffer_->data() &&
+      copy->qc_buffer_ && copy->qc_buffer_->data())
+    {
+      std::memcpy(copy->qc_buffer_->data(), qc_buffer_->data(), size_ * sizeof(T));
+    }
+    return copy;
+  }
+
+  const std::shared_ptr<QcBuffer> & get_qc_buffer() const {return qc_buffer_;}
+  std::shared_ptr<QcBuffer> & get_qc_buffer() {return qc_buffer_;}
+
+private:
+  size_t size_;
+  std::shared_ptr<QcBuffer> qc_buffer_;
+};
+
+}  // namespace qc_buffer_backend
+
+#endif  // QC_BUFFER__QC_BUFFER_IMPL_HPP_

--- a/qc_buffer_backend/qc_buffer/include/qc_buffer/qc_error.hpp
+++ b/qc_buffer_backend/qc_buffer/include/qc_buffer/qc_error.hpp
@@ -1,0 +1,37 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QC_BUFFER__QC_ERROR_HPP_
+#define QC_BUFFER__QC_ERROR_HPP_
+
+#include <stdexcept>
+#include <string>
+
+namespace qc_buffer_backend
+{
+
+/// \brief Exception type for qc_buffer errors that break the API contract
+/// (e.g. an explicit qc allocation request that fails, or a type mismatch).
+/// Environmental or scenario limitations that merely prevent zero-copy are
+/// handled by graceful CPU fallback, not by throwing.
+class QcError : public std::runtime_error
+{
+public:
+  explicit QcError(const std::string & message)
+  : std::runtime_error(message) {}
+};
+
+}  // namespace qc_buffer_backend
+
+#endif  // QC_BUFFER__QC_ERROR_HPP_

--- a/qc_buffer_backend/qc_buffer/include/qc_buffer/rpcmem_loader.hpp
+++ b/qc_buffer_backend/qc_buffer/include/qc_buffer/rpcmem_loader.hpp
@@ -1,0 +1,82 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QC_BUFFER__RPCMEM_LOADER_HPP_
+#define QC_BUFFER__RPCMEM_LOADER_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+#include "qc_buffer/visibility_control.h"
+
+namespace qc_buffer_backend
+{
+
+/// ION heap id used for FastRPC-mappable system memory (matches the value
+/// used by qrb_ros_*_with_dma).
+inline constexpr int kRpcmemHeapIdSystem = 25;
+
+/// Default ION allocation flags (matches qrb_ros_*_with_dma).
+inline constexpr uint32_t kRpcmemDefaultFlags = 1;
+
+/// \brief Process-wide loader for the Qualcomm rpcmem (FastRPC/ION) library.
+///
+/// Wraps dlopen("libcdsprpc.so") and resolves the rpcmem_* symbols. On
+/// devices where the library is missing (e.g. developer hosts), available()
+/// returns false and the backend transparently falls back to the CPU path.
+/// The instance is created lazily and lives for the process lifetime.
+class QC_BUFFER_PUBLIC RpcMemLoader
+{
+public:
+  static RpcMemLoader & instance();
+
+  /// True if the library loaded and every required symbol resolved.
+  bool available() const {return available_;}
+
+  /// Allocate an ION/dma-buf buffer. Returns nullptr on failure or when the
+  /// library is unavailable.
+  void * alloc(int heap_id, uint32_t flags, size_t size);
+
+  /// Free a buffer previously returned by alloc().
+  void free(void * ptr);
+
+  /// Return the dma-buf fd for a buffer, or -1 on failure/unavailable.
+  int to_fd(void * ptr);
+
+private:
+  RpcMemLoader();
+  ~RpcMemLoader();
+
+  RpcMemLoader(const RpcMemLoader &) = delete;
+  RpcMemLoader & operator=(const RpcMemLoader &) = delete;
+
+  using RpcMemInitFn = void (*)(void);
+  using RpcMemDeinitFn = void (*)(void);
+  using RpcMemAllocFn = void * (*)(int, uint32_t, int);
+  using RpcMemFreeFn = void (*)(void *);
+  using RpcMemToFdFn = int (*)(void *);
+
+  void * lib_{nullptr};
+  bool available_{false};
+
+  RpcMemInitFn init_{nullptr};
+  RpcMemDeinitFn deinit_{nullptr};
+  RpcMemAllocFn alloc_{nullptr};
+  RpcMemFreeFn free_{nullptr};
+  RpcMemToFdFn to_fd_{nullptr};
+};
+
+}  // namespace qc_buffer_backend
+
+#endif  // QC_BUFFER__RPCMEM_LOADER_HPP_

--- a/qc_buffer_backend/qc_buffer/include/qc_buffer/visibility_control.h
+++ b/qc_buffer_backend/qc_buffer/include/qc_buffer/visibility_control.h
@@ -1,0 +1,53 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QC_BUFFER__VISIBILITY_CONTROL_H_
+#define QC_BUFFER__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define QC_BUFFER_EXPORT __attribute__ ((dllexport))
+    #define QC_BUFFER_IMPORT __attribute__ ((dllimport))
+  #else
+    #define QC_BUFFER_EXPORT __declspec(dllexport)
+    #define QC_BUFFER_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef QC_BUFFER_BUILDING_DLL
+    #define QC_BUFFER_PUBLIC QC_BUFFER_EXPORT
+  #else
+    #define QC_BUFFER_PUBLIC QC_BUFFER_IMPORT
+  #endif
+  #define QC_BUFFER_LOCAL
+#else
+  #define QC_BUFFER_EXPORT __attribute__ ((visibility("default")))
+  #define QC_BUFFER_IMPORT
+  #if __GNUC__ >= 4
+    #define QC_BUFFER_PUBLIC __attribute__ ((visibility("default")))
+    #define QC_BUFFER_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define QC_BUFFER_PUBLIC
+    #define QC_BUFFER_LOCAL
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // QC_BUFFER__VISIBILITY_CONTROL_H_

--- a/qc_buffer_backend/qc_buffer/package.xml
+++ b/qc_buffer_backend/qc_buffer/package.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>qc_buffer</name>
+  <version>0.1.0</version>
+  <description>ION/dma-buf backed rosidl::Buffer storage for Qualcomm platforms,
+  providing CPU-accessible memory that can be shared zero-copy with the HTP
+  via a dma-buf fd.</description>
+
+  <maintainer email="nasong@qti.qualcomm.com">Na Song</maintainer>
+  <license>Apache-2.0</license>
+  <author email="nasong@qti.qualcomm.com">Na Song</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rosidl_buffer</depend>
+  <depend>qc_buffer_backend_msgs</depend>
+  <depend>rmw</depend>
+  <depend>rcutils</depend>
+
+  <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/qc_buffer_backend/qc_buffer/src/fd_broker.cpp
+++ b/qc_buffer_backend/qc_buffer/src/fd_broker.cpp
@@ -1,0 +1,219 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "qc_buffer/fd_broker.hpp"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cinttypes>
+#include <cstring>
+#include <string>
+
+#include "rcutils/logging_macros.h"
+
+namespace qc_buffer_backend
+{
+
+FdBroker & FdBroker::instance()
+{
+  static FdBroker broker;
+  return broker;
+}
+
+FdBroker::FdBroker()
+{
+  start();
+}
+
+FdBroker::~FdBroker()
+{
+  running_ = false;
+  if (server_fd_ >= 0) {
+    ::shutdown(server_fd_, SHUT_RDWR);
+    ::close(server_fd_);
+    server_fd_ = -1;
+  }
+  if (!socket_path_.empty()) {
+    ::unlink(socket_path_.c_str());
+  }
+  if (worker_.joinable()) {
+    worker_.join();
+  }
+  // Wait for detached handle_connection threads to finish before teardown.
+  while (active_connections_.load(std::memory_order_acquire) > 0) {
+    std::this_thread::yield();
+  }
+  std::lock_guard<std::mutex> lock(mutex_);
+  for (auto & [uid, entry] : table_) {
+    ::close(entry.dup_fd);
+  }
+  table_.clear();
+}
+
+void FdBroker::start()
+{
+  server_fd_ = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (server_fd_ < 0) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "qc_buffer_backend", "FdBroker: socket() failed: %s", strerror(errno));
+    return;
+  }
+
+  socket_path_ = "/tmp/qc_broker_" + std::to_string(getpid()) + ".sock";
+  ::unlink(socket_path_.c_str());
+
+  struct sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  std::strncpy(addr.sun_path, socket_path_.c_str(), sizeof(addr.sun_path) - 1);
+
+  if (::bind(server_fd_, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) < 0) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "qc_buffer_backend", "FdBroker: bind() failed: %s", strerror(errno));
+    ::close(server_fd_);
+    server_fd_ = -1;
+    return;
+  }
+
+  if (::listen(server_fd_, 16) < 0) {
+    RCUTILS_LOG_ERROR_NAMED(
+      "qc_buffer_backend", "FdBroker: listen() failed: %s", strerror(errno));
+    ::close(server_fd_);
+    server_fd_ = -1;
+    return;
+  }
+
+  running_ = true;
+  worker_ = std::thread(&FdBroker::worker_loop, this);
+}
+
+void FdBroker::worker_loop()
+{
+  while (running_) {
+    int conn_fd = ::accept(server_fd_, nullptr, nullptr);
+    if (conn_fd < 0) {
+      if (!running_) {
+        break;
+      }
+      RCUTILS_LOG_WARN_NAMED(
+        "qc_buffer_backend", "FdBroker: accept() failed: %s", strerror(errno));
+      continue;
+    }
+    active_connections_.fetch_add(1, std::memory_order_relaxed);
+    std::thread([this, conn_fd]() {handle_connection(conn_fd);}).detach();
+  }
+}
+
+void FdBroker::handle_connection(int conn_fd)
+{
+  // 500 ms timeout on send/recv to avoid blocking indefinitely.
+  struct timeval tv{0, 500'000};
+  ::setsockopt(conn_fd, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  ::setsockopt(conn_fd, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+  // Read request: [uint64_t uid]
+  uint64_t uid = 0;
+  ssize_t n = ::recv(conn_fd, &uid, sizeof(uid), MSG_WAITALL);
+  if (n != static_cast<ssize_t>(sizeof(uid))) {
+    ::close(conn_fd);
+    active_connections_.fetch_sub(1, std::memory_order_release);
+    return;
+  }
+
+  // Dup the stored fd while holding the lock; release lock before sendmsg.
+  int tmp_fd = -1;
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = table_.find(uid);
+    if (it == table_.end()) {
+      uint8_t miss = kStatusMiss;
+      ::send(conn_fd, &miss, 1, MSG_NOSIGNAL);
+      ::close(conn_fd);
+      active_connections_.fetch_sub(1, std::memory_order_release);
+      return;
+    }
+    tmp_fd = ::dup(it->second.dup_fd);
+  }
+
+  if (tmp_fd < 0) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "FdBroker: dup() failed for uid %" PRIu64 ": %s",
+      uid, strerror(errno));
+    uint8_t miss = kStatusMiss;
+    ::send(conn_fd, &miss, 1, MSG_NOSIGNAL);
+    ::close(conn_fd);
+    active_connections_.fetch_sub(1, std::memory_order_release);
+    return;
+  }
+
+  // Send fd via SCM_RIGHTS.
+  uint8_t status = kStatusOk;
+  struct iovec iov{&status, 1};
+  union {
+    char buf[CMSG_SPACE(sizeof(int))];
+    struct cmsghdr align;
+  } cmsg_buf{};
+
+  struct msghdr msg{};
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = cmsg_buf.buf;
+  msg.msg_controllen = sizeof(cmsg_buf.buf);
+
+  struct cmsghdr * cmsg = CMSG_FIRSTHDR(&msg);
+  cmsg->cmsg_level = SOL_SOCKET;
+  cmsg->cmsg_type = SCM_RIGHTS;
+  cmsg->cmsg_len = CMSG_LEN(sizeof(int));
+  std::memcpy(CMSG_DATA(cmsg), &tmp_fd, sizeof(int));
+
+  ::sendmsg(conn_fd, &msg, MSG_NOSIGNAL);
+  ::close(tmp_fd);
+  ::close(conn_fd);
+  active_connections_.fetch_sub(1, std::memory_order_release);
+}
+
+void FdBroker::register_buffer(uint64_t uid, int fd, uint64_t dmabuf_size)
+{
+  if (!running_ || uid == 0 || fd < 0) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (table_.count(uid)) {
+    return;  // Idempotent: same uid from a second endpoint call.
+  }
+  int dup_fd = ::dup(fd);
+  if (dup_fd < 0) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "FdBroker: dup() failed during register uid %" PRIu64 ": %s",
+      uid, strerror(errno));
+    return;
+  }
+  table_[uid] = {dup_fd, dmabuf_size};
+  order_.push_back(uid);
+  while (order_.size() > kCapacity) {
+    uint64_t old = order_.front();
+    order_.pop_front();
+    auto it = table_.find(old);
+    if (it != table_.end()) {
+      ::close(it->second.dup_fd);
+      table_.erase(it);
+    }
+  }
+}
+
+}  // namespace qc_buffer_backend

--- a/qc_buffer_backend/qc_buffer/src/qc_buffer.cpp
+++ b/qc_buffer_backend/qc_buffer/src/qc_buffer.cpp
@@ -1,0 +1,126 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "qc_buffer/qc_buffer.hpp"
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <string>
+#include <utility>
+
+#include "qc_buffer/qc_error.hpp"
+#include "qc_buffer/rpcmem_loader.hpp"
+
+namespace qc_buffer_backend
+{
+
+namespace
+{
+
+uint64_t next_uid()
+{
+  static std::atomic<uint64_t> counter{1};
+  return counter.fetch_add(1, std::memory_order_relaxed);
+}
+
+}  // namespace
+
+QcBuffer::QcBuffer(size_t byte_size)
+{
+  if (byte_size == 0) {
+    return;
+  }
+
+  auto & loader = RpcMemLoader::instance();
+  if (!loader.available()) {
+    throw QcError(
+            "qc buffer allocation requested but rpcmem (libcdsprpc.so) is unavailable");
+  }
+
+  ptr_ = static_cast<uint8_t *>(
+    loader.alloc(kRpcmemHeapIdSystem, kRpcmemDefaultFlags, byte_size));
+  if (ptr_ == nullptr) {
+    throw QcError("rpcmem_alloc failed for " + std::to_string(byte_size) + " bytes");
+  }
+
+  fd_ = loader.to_fd(ptr_);
+  if (fd_ < 0) {
+    loader.free(ptr_);
+    ptr_ = nullptr;
+    throw QcError("rpcmem_to_fd failed");
+  }
+
+  size_ = byte_size;
+  uid_ = next_uid();
+  origin_ = Origin::kRpcmem;
+}
+
+QcBuffer::QcBuffer(uint8_t * ptr, size_t size, int fd)
+: ptr_(ptr), fd_(fd), size_(size), uid_(next_uid()), origin_(Origin::kMmap)
+{
+}
+
+QcBuffer::~QcBuffer()
+{
+  reset();
+}
+
+QcBuffer::QcBuffer(QcBuffer && other) noexcept
+: ptr_(other.ptr_), fd_(other.fd_), size_(other.size_),
+  uid_(other.uid_), origin_(other.origin_)
+{
+  other.ptr_ = nullptr;
+  other.fd_ = -1;
+  other.size_ = 0;
+  other.uid_ = 0;
+}
+
+QcBuffer & QcBuffer::operator=(QcBuffer && other) noexcept
+{
+  if (this != &other) {
+    reset();
+    ptr_ = other.ptr_;
+    fd_ = other.fd_;
+    size_ = other.size_;
+    uid_ = other.uid_;
+    origin_ = other.origin_;
+    other.ptr_ = nullptr;
+    other.fd_ = -1;
+    other.size_ = 0;
+    other.uid_ = 0;
+  }
+  return *this;
+}
+
+void QcBuffer::reset() noexcept
+{
+  if (ptr_ != nullptr) {
+    if (origin_ == Origin::kMmap) {
+      ::munmap(ptr_, size_);
+      if (fd_ >= 0) {
+        ::close(fd_);
+      }
+    } else {
+      RpcMemLoader::instance().free(ptr_);
+    }
+    ptr_ = nullptr;
+  }
+  fd_ = -1;
+  size_ = 0;
+  uid_ = 0;
+}
+
+}  // namespace qc_buffer_backend

--- a/qc_buffer_backend/qc_buffer/src/rpcmem_loader.cpp
+++ b/qc_buffer_backend/qc_buffer/src/rpcmem_loader.cpp
@@ -1,0 +1,96 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "qc_buffer/rpcmem_loader.hpp"
+
+#include <dlfcn.h>
+
+#include <rcutils/logging_macros.h>
+
+namespace qc_buffer_backend
+{
+
+RpcMemLoader & RpcMemLoader::instance()
+{
+  static RpcMemLoader loader;
+  return loader;
+}
+
+RpcMemLoader::RpcMemLoader()
+{
+  lib_ = ::dlopen("libcdsprpc.so", RTLD_NOW | RTLD_LOCAL);
+  if (lib_ == nullptr) {
+    RCUTILS_LOG_WARN_NAMED("qc_buffer_backend",
+      "libcdsprpc.so not available (%s); qc buffers will fall back to CPU",
+      ::dlerror());
+    return;
+  }
+
+  init_ = reinterpret_cast<RpcMemInitFn>(::dlsym(lib_, "rpcmem_init"));
+  deinit_ = reinterpret_cast<RpcMemDeinitFn>(::dlsym(lib_, "rpcmem_deinit"));
+  alloc_ = reinterpret_cast<RpcMemAllocFn>(::dlsym(lib_, "rpcmem_alloc"));
+  free_ = reinterpret_cast<RpcMemFreeFn>(::dlsym(lib_, "rpcmem_free"));
+  to_fd_ = reinterpret_cast<RpcMemToFdFn>(::dlsym(lib_, "rpcmem_to_fd"));
+
+  if (alloc_ == nullptr || free_ == nullptr || to_fd_ == nullptr) {
+    RCUTILS_LOG_WARN_NAMED("qc_buffer_backend",
+      "rpcmem symbols missing in libcdsprpc.so; qc buffers will fall back to CPU");
+    ::dlclose(lib_);
+    lib_ = nullptr;
+    return;
+  }
+
+  if (init_ != nullptr) {
+    init_();
+  }
+
+  available_ = true;
+  RCUTILS_LOG_INFO_NAMED("qc_buffer_backend", "rpcmem initialized");
+}
+
+RpcMemLoader::~RpcMemLoader()
+{
+  if (lib_ != nullptr) {
+    if (deinit_ != nullptr) {
+      deinit_();
+    }
+    ::dlclose(lib_);
+    lib_ = nullptr;
+  }
+}
+
+void * RpcMemLoader::alloc(int heap_id, uint32_t flags, size_t size)
+{
+  if (!available_) {
+    return nullptr;
+  }
+  return alloc_(heap_id, flags, static_cast<int>(size));
+}
+
+void RpcMemLoader::free(void * ptr)
+{
+  if (available_ && ptr != nullptr) {
+    free_(ptr);
+  }
+}
+
+int RpcMemLoader::to_fd(void * ptr)
+{
+  if (!available_ || ptr == nullptr) {
+    return -1;
+  }
+  return to_fd_(ptr);
+}
+
+}  // namespace qc_buffer_backend

--- a/qc_buffer_backend/qc_buffer/test/test_qc_buffer.cpp
+++ b/qc_buffer_backend/qc_buffer/test/test_qc_buffer.cpp
@@ -1,0 +1,437 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cinttypes>
+#include <cstring>
+#include <memory>
+#include <thread>
+#include <vector>
+
+#include "qc_buffer/fd_broker.hpp"
+#include "qc_buffer/qc_buffer.hpp"
+#include "qc_buffer/qc_buffer_api.hpp"
+#include "qc_buffer/qc_buffer_impl.hpp"
+#include "qc_buffer/rpcmem_loader.hpp"
+#include "rosidl_buffer/buffer.hpp"
+#include "rosidl_buffer/cpu_buffer_impl.hpp"
+
+using qc_buffer_backend::FdBroker;
+using qc_buffer_backend::QcBuffer;
+using qc_buffer_backend::QcBufferImpl;
+using qc_buffer_backend::RpcMemLoader;
+
+// ── RpcMemLoader ─────────────────────────────────────────────────────────────
+
+// Singleton returns the same instance on repeated calls.
+TEST(RpcMemLoaderTest, SingletonIdentity)
+{
+  EXPECT_EQ(&RpcMemLoader::instance(), &RpcMemLoader::instance());
+}
+
+// On a Qualcomm device with libcdsprpc.so, available() must return true.
+// Skips gracefully on host machines where the library is absent.
+TEST(RpcMemLoaderTest, AvailableOnDevice)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "libcdsprpc.so not found; this check requires a Qualcomm device";
+  }
+  EXPECT_TRUE(RpcMemLoader::instance().available());
+}
+
+// alloc(0) returns nullptr without crashing when library is available.
+TEST(RpcMemLoaderTest, AllocZeroReturnsNullptr)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  void * p = RpcMemLoader::instance().alloc(
+    qc_buffer_backend::kRpcmemHeapIdSystem,
+    qc_buffer_backend::kRpcmemDefaultFlags,
+    0);
+  // rpcmem_alloc(0) behaviour is implementation-defined; just ensure no crash.
+  if (p != nullptr) {
+    RpcMemLoader::instance().free(p);
+  }
+}
+
+// ── QcBuffer ─────────────────────────────────────────────────────────────────
+
+// Default-constructed buffer is empty.
+TEST(QcBufferTest, DefaultConstructedIsEmpty)
+{
+  QcBuffer buf;
+  EXPECT_EQ(buf.data(), nullptr);
+  EXPECT_EQ(buf.dmabuf_fd(), -1);
+  EXPECT_EQ(buf.size(), 0u);
+  EXPECT_EQ(buf.uid(), 0u);
+}
+
+// Allocating a non-zero buffer succeeds and fields are populated.
+TEST(QcBufferTest, AllocPopulatesFields)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBuffer buf(64);
+  EXPECT_NE(buf.data(), nullptr);
+  EXPECT_GE(buf.dmabuf_fd(), 0);
+  EXPECT_EQ(buf.size(), 64u);
+  EXPECT_GT(buf.uid(), 0u);
+}
+
+// Two allocations receive distinct uids.
+TEST(QcBufferTest, DistinctUids)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBuffer a(32);
+  QcBuffer b(32);
+  EXPECT_NE(a.uid(), b.uid());
+}
+
+// CPU writes are readable through the same pointer.
+TEST(QcBufferTest, CpuReadWrite)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBuffer buf(8);
+  for (size_t i = 0; i < 8; ++i) {
+    buf.data()[i] = static_cast<uint8_t>(i + 1);
+  }
+  for (size_t i = 0; i < 8; ++i) {
+    EXPECT_EQ(buf.data()[i], static_cast<uint8_t>(i + 1));
+  }
+}
+
+// Move constructor transfers ownership; source is left empty.
+TEST(QcBufferTest, MoveConstructor)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBuffer a(32);
+  uint8_t * orig_data = a.data();
+  uint64_t orig_uid = a.uid();
+  QcBuffer b(std::move(a));
+  EXPECT_EQ(b.data(), orig_data);
+  EXPECT_EQ(b.uid(), orig_uid);
+  EXPECT_EQ(a.data(), nullptr);
+  EXPECT_EQ(a.dmabuf_fd(), -1);
+  EXPECT_EQ(a.uid(), 0u);
+}
+
+// kMmap path: constructor accepts an externally mmap-ed pointer.
+TEST(QcBufferTest, MmapOriginConstructor)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBuffer src(64);
+  ASSERT_GE(src.dmabuf_fd(), 0);
+
+  int dup_fd = ::dup(src.dmabuf_fd());
+  ASSERT_GE(dup_fd, 0);
+  void * ptr = ::mmap(nullptr, 64, PROT_READ | PROT_WRITE, MAP_SHARED, dup_fd, 0);
+  ASSERT_NE(ptr, MAP_FAILED);
+
+  QcBuffer mapped(static_cast<uint8_t *>(ptr), 64, dup_fd);
+  EXPECT_EQ(mapped.data(), ptr);
+  EXPECT_EQ(mapped.dmabuf_fd(), dup_fd);
+  EXPECT_EQ(mapped.size(), 64u);
+  EXPECT_GT(mapped.uid(), 0u);
+  // Destructor calls munmap + close(dup_fd); verified by absence of ASAN leak.
+}
+
+// ── QcBufferImpl ─────────────────────────────────────────────────────────────
+
+// Default-constructed impl reports "qc" backend and size 0.
+TEST(QcBufferImplTest, DefaultConstructed)
+{
+  QcBufferImpl<uint8_t> impl;
+  EXPECT_EQ(impl.get_backend_type(), "qc");
+  EXPECT_EQ(impl.size(), 0u);
+  EXPECT_EQ(impl.get_qc_buffer(), nullptr);
+}
+
+// Size constructor allocates a real buffer.
+TEST(QcBufferImplTest, SizeConstructor)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBufferImpl<uint8_t> impl(16);
+  EXPECT_EQ(impl.size(), 16u);
+  ASSERT_NE(impl.get_qc_buffer(), nullptr);
+  EXPECT_NE(impl.get_qc_buffer()->data(), nullptr);
+  EXPECT_GE(impl.get_qc_buffer()->dmabuf_fd(), 0);
+}
+
+// to_cpu() copies bytes to a CPU buffer correctly.
+TEST(QcBufferImplTest, ToCpuCopiesBytes)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBufferImpl<uint8_t> impl(4);
+  ASSERT_NE(impl.get_qc_buffer(), nullptr);
+  impl.get_qc_buffer()->data()[0] = 0xAA;
+  impl.get_qc_buffer()->data()[3] = 0xBB;
+
+  auto cpu = impl.to_cpu();
+  ASSERT_NE(cpu, nullptr);
+  EXPECT_EQ(cpu->size(), 4u);
+
+  auto * cpu_impl = dynamic_cast<rosidl::CpuBufferImpl<uint8_t> *>(cpu.get());
+  ASSERT_NE(cpu_impl, nullptr);
+  EXPECT_EQ(cpu_impl->get_storage()[0], 0xAA);
+  EXPECT_EQ(cpu_impl->get_storage()[3], 0xBB);
+}
+
+// clone() produces an independent deep copy.
+TEST(QcBufferImplTest, CloneIsIndependent)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBufferImpl<uint8_t> impl(4);
+  impl.get_qc_buffer()->data()[0] = 0x42;
+
+  auto copy = impl.clone();
+  ASSERT_NE(copy, nullptr);
+  EXPECT_EQ(copy->size(), 4u);
+  // Mutate original; clone must be unaffected.
+  impl.get_qc_buffer()->data()[0] = 0xFF;
+  auto copy_cpu = copy->to_cpu();
+  auto * cpu_copy = dynamic_cast<rosidl::CpuBufferImpl<uint8_t> *>(copy_cpu.get());
+  ASSERT_NE(cpu_copy, nullptr);
+  EXPECT_EQ(cpu_copy->get_storage()[0], 0x42);
+}
+
+// Cross-process constructor throws when given a valid fd that cannot be
+// MAP_SHARED mmap-ed (e.g. a pipe read-end). This matches the real production
+// failure mode when SCM_RIGHTS delivers the wrong fd type.
+// The constructor must close the fd before throwing (ownership transfer).
+TEST(QcBufferImplTest, MmapConstructorThrowsOnNonMmapableFd)
+{
+  int pipe_fds[2];
+  ASSERT_EQ(::pipe(pipe_fds), 0);
+  int read_fd = pipe_fds[0];
+  ::close(pipe_fds[1]);
+
+  EXPECT_THROW((QcBufferImpl<uint8_t>{read_fd, 64, 64}), std::exception);
+
+  // Constructor must have closed read_fd; a second close returns EBADF.
+  EXPECT_EQ(::close(read_fd), -1);
+  EXPECT_EQ(errno, EBADF);
+}
+
+// Cross-process constructor succeeds with a valid dma-buf dup fd.
+TEST(QcBufferImplTest, MmapConstructorSucceeds)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBuffer src(64);
+  src.data()[0] = 0xAB;
+
+  int dup_fd = ::dup(src.dmabuf_fd());
+  ASSERT_GE(dup_fd, 0);
+
+  QcBufferImpl<uint8_t> impl(dup_fd, src.size(), 64);
+  EXPECT_EQ(impl.size(), 64u);
+  EXPECT_EQ(impl.get_backend_type(), "qc");
+  ASSERT_NE(impl.get_qc_buffer(), nullptr);
+  EXPECT_EQ(impl.get_qc_buffer()->data()[0], 0xAB);
+}
+
+// ── qc_buffer_api ────────────────────────────────────────────────────────────
+
+// allocate_buffer returns a qc-backed buffer with the requested size.
+TEST(QcBufferApiTest, AllocateBufferReturnsQcBackend)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  auto buf = qc_buffer_backend::allocate_buffer(32);
+  EXPECT_EQ(buf.get_backend_type(), "qc");
+  EXPECT_EQ(buf.size(), 32u);
+}
+
+// get_dmabuf_fd returns a valid fd for a qc-backed buffer.
+TEST(QcBufferApiTest, GetDmabufFdIsValid)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  auto buf = qc_buffer_backend::allocate_buffer(16);
+  EXPECT_GE(qc_buffer_backend::get_dmabuf_fd(buf), 0);
+}
+
+// get_data_ptr returns a non-null CPU pointer.
+TEST(QcBufferApiTest, GetDataPtrIsNonNull)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  auto buf = qc_buffer_backend::allocate_buffer(8);
+  EXPECT_NE(qc_buffer_backend::get_data_ptr(buf), nullptr);
+}
+
+// get_dmabuf_fd returns -1 for a default-constructed (CPU) buffer.
+TEST(QcBufferApiTest, GetDmabufFdReturnsMinus1ForCpuBuffer)
+{
+  rosidl::Buffer<uint8_t> buf;
+  EXPECT_EQ(qc_buffer_backend::get_dmabuf_fd(buf), -1);
+}
+
+// ── FdBroker ─────────────────────────────────────────────────────────────────
+
+// Singleton returns the same instance.
+TEST(FdBrokerTest, SingletonIdentity)
+{
+  EXPECT_EQ(&FdBroker::instance(), &FdBroker::instance());
+}
+
+// Broker starts successfully.
+TEST(FdBrokerTest, StartsRunning)
+{
+  EXPECT_TRUE(FdBroker::instance().running());
+}
+
+// Socket path contains the process pid.
+TEST(FdBrokerTest, SocketPathContainsPid)
+{
+  const std::string & path = FdBroker::instance().socket_path();
+  EXPECT_FALSE(path.empty());
+  EXPECT_NE(path.find(std::to_string(getpid())), std::string::npos);
+}
+
+// register_buffer with invalid arguments is silently ignored.
+TEST(FdBrokerTest, RegisterInvalidArgsIgnored)
+{
+  EXPECT_NO_THROW(FdBroker::instance().register_buffer(0, 42, 100));
+  EXPECT_NO_THROW(FdBroker::instance().register_buffer(1, -1, 100));
+}
+
+// A registered buffer can be retrieved via the socket (SCM_RIGHTS).
+TEST(FdBrokerTest, RegisterAndRetrieveFd)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  auto buf = std::make_shared<QcBuffer>(64);
+  auto & broker = FdBroker::instance();
+  broker.register_buffer(buf->uid(), buf->dmabuf_fd(), buf->size());
+
+  int sock = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  ASSERT_GE(sock, 0);
+  struct sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  std::strncpy(addr.sun_path, broker.socket_path().c_str(), sizeof(addr.sun_path) - 1);
+  ASSERT_EQ(::connect(sock, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)), 0);
+
+  uint64_t uid = buf->uid();
+  ASSERT_EQ(::send(sock, &uid, sizeof(uid), 0), static_cast<ssize_t>(sizeof(uid)));
+
+  uint8_t status = 0;
+  struct iovec iov{&status, 1};
+  union { char b[CMSG_SPACE(sizeof(int))]; struct cmsghdr a; } cmsg_buf{};
+  struct msghdr msg{};
+  msg.msg_iov = &iov; msg.msg_iovlen = 1;
+  msg.msg_control = cmsg_buf.b; msg.msg_controllen = sizeof(cmsg_buf.b);
+  struct timeval tv{1, 0};
+  ::setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  ASSERT_GT(::recvmsg(sock, &msg, 0), 0);
+  ::close(sock);
+
+  EXPECT_EQ(status, 0x01);
+  int received_fd = -1;
+  struct cmsghdr * cmsg = CMSG_FIRSTHDR(&msg);
+  if (cmsg) {std::memcpy(&received_fd, CMSG_DATA(cmsg), sizeof(int));}
+  ASSERT_GE(received_fd, 0);
+  ::close(received_fd);
+}
+
+// Unknown uid returns kStatusMiss (0x02).
+TEST(FdBrokerTest, UnknownUidReturnsMiss)
+{
+  auto & broker = FdBroker::instance();
+  int sock = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  ASSERT_GE(sock, 0);
+  struct sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  std::strncpy(addr.sun_path, broker.socket_path().c_str(), sizeof(addr.sun_path) - 1);
+  ASSERT_EQ(::connect(sock, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)), 0);
+
+  uint64_t uid = 0xDEADDEADDEADDEADULL;
+  ::send(sock, &uid, sizeof(uid), 0);
+
+  uint8_t status = 0xFF;
+  struct iovec iov{&status, 1};
+  union { char b[CMSG_SPACE(sizeof(int))]; struct cmsghdr a; } cmsg_buf{};
+  struct msghdr msg{};
+  msg.msg_iov = &iov; msg.msg_iovlen = 1;
+  msg.msg_control = cmsg_buf.b; msg.msg_controllen = sizeof(cmsg_buf.b);
+  struct timeval tv{1, 0};
+  ::setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  ::recvmsg(sock, &msg, 0);
+  ::close(sock);
+  EXPECT_EQ(status, 0x02);
+}
+
+// Registering the same uid twice is idempotent (no duplicate entry).
+TEST(FdBrokerTest, RegisterSameUidIdempotent)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  auto buf = std::make_shared<QcBuffer>(32);
+  auto & broker = FdBroker::instance();
+  broker.register_buffer(buf->uid(), buf->dmabuf_fd(), buf->size());
+  EXPECT_NO_THROW(
+    broker.register_buffer(buf->uid(), buf->dmabuf_fd(), buf->size()));
+}
+
+// Broker survives a subscriber that disconnects immediately after sending uid.
+TEST(FdBrokerTest, EarlyDisconnectDoesNotCrashBroker)
+{
+  auto & broker = FdBroker::instance();
+  int sock = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  ASSERT_GE(sock, 0);
+  struct sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  std::strncpy(addr.sun_path, broker.socket_path().c_str(), sizeof(addr.sun_path) - 1);
+  ASSERT_EQ(::connect(sock, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)), 0);
+  uint64_t uid = 0xBADFEED0ULL;
+  ::send(sock, &uid, sizeof(uid), 0);
+  ::close(sock);
+  std::this_thread::sleep_for(std::chrono::milliseconds(30));
+  EXPECT_TRUE(broker.running());
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/qc_buffer_backend/qc_buffer_backend/CMakeLists.txt
+++ b/qc_buffer_backend/qc_buffer_backend/CMakeLists.txt
@@ -37,6 +37,20 @@ pluginlib_export_plugin_description_file(rosidl_buffer_backend qc_buffer_plugin.
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_qc_buffer_backend
+    test/test_qc_buffer_backend.cpp
+  )
+  if(TARGET test_qc_buffer_backend)
+    target_link_libraries(test_qc_buffer_backend
+      ${PROJECT_NAME}
+      qc_buffer::qc_buffer
+      ${qc_buffer_backend_msgs_TARGETS}
+      rosidl_buffer::rosidl_buffer
+      rosidl_buffer_backend::rosidl_buffer_backend
+    )
+  endif()
 endif()
 
 ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/qc_buffer_backend/qc_buffer_backend/CMakeLists.txt
+++ b/qc_buffer_backend/qc_buffer_backend/CMakeLists.txt
@@ -1,0 +1,42 @@
+cmake_minimum_required(VERSION 3.20)
+project(qc_buffer_backend)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake_auto REQUIRED)
+ament_auto_find_build_dependencies()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/qc_buffer_backend_plugin.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include/${PROJECT_NAME}>
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${qc_buffer_backend_msgs_TARGETS}
+  rosidl_buffer_backend::rosidl_buffer_backend
+  rosidl_runtime_cpp::rosidl_runtime_cpp
+  rosidl_buffer_backend_registry::rosidl_buffer_backend_registry
+  rosidl_typesupport_cpp::rosidl_typesupport_cpp
+  pluginlib::pluginlib
+  qc_buffer::qc_buffer
+  rcutils::rcutils
+)
+
+pluginlib_export_plugin_description_file(rosidl_buffer_backend qc_buffer_plugin.xml)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package(USE_SCOPED_HEADER_INSTALL_DIR)

--- a/qc_buffer_backend/qc_buffer_backend/include/qc_buffer_backend/qc_buffer_backend.hpp
+++ b/qc_buffer_backend/qc_buffer_backend/include/qc_buffer_backend/qc_buffer_backend.hpp
@@ -1,0 +1,61 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef QC_BUFFER_BACKEND__QC_BUFFER_BACKEND_HPP_
+#define QC_BUFFER_BACKEND__QC_BUFFER_BACKEND_HPP_
+
+#include <memory>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include "rmw/topic_endpoint_info.h"
+#include "rosidl_buffer_backend/buffer_backend.hpp"
+
+namespace qc_buffer_backend
+{
+
+/// \brief Qualcomm buffer backend plugin for zero-copy sharing of ION/dma-buf
+/// memory between CPU and HTP accelerator.
+///
+/// Both same-process and cross-process subscribers use the same FdBroker +
+/// SCM_RIGHTS + mmap path. The publisher registers each buffer's dma-buf fd
+/// with FdBroker; any subscriber (same or different process) connects to the
+/// broker socket, receives a fd copy via SCM_RIGHTS, and mmap()s it to access
+/// the same physical memory without copying.
+class QcBufferBackend : public rosidl::BufferBackend
+{
+public:
+  QcBufferBackend() = default;
+  ~QcBufferBackend() override = default;
+
+  std::string get_backend_type() const override {return "qc";}
+
+  const rosidl_message_type_support_t * get_descriptor_type_support() const override;
+  std::shared_ptr<void> create_empty_descriptor() const override;
+
+  std::shared_ptr<void> create_descriptor_with_endpoint(
+    const void * impl,
+    const rmw_topic_endpoint_info_t & endpoint_info) const override;
+
+  std::unique_ptr<void, void (*)(void *)> from_descriptor_with_endpoint(
+    const void * descriptor,
+    const rmw_topic_endpoint_info_t & endpoint_info) const override;
+};
+
+}  // namespace qc_buffer_backend
+
+#endif  // QC_BUFFER_BACKEND__QC_BUFFER_BACKEND_HPP_

--- a/qc_buffer_backend/qc_buffer_backend/package.xml
+++ b/qc_buffer_backend/qc_buffer_backend/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>qc_buffer_backend</name>
+  <version>0.1.0</version>
+  <description>Pluginlib backend for ION/dma-buf backed rosidl::Buffer transport
+  on Qualcomm platforms, providing intra-process HTP-CPU zero-copy with CPU
+  fallback otherwise.</description>
+
+  <maintainer email="nasong@qti.qualcomm.com">Na Song</maintainer>
+  <license>Apache-2.0</license>
+  <author email="nasong@qti.qualcomm.com">Na Song</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <depend>qc_buffer</depend>
+  <depend>qc_buffer_backend_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rcutils</depend>
+  <depend>rosidl_buffer_backend</depend>
+  <depend>rosidl_buffer_backend_registry</depend>
+  <depend>rosidl_runtime_cpp</depend>
+  <depend>rosidl_typesupport_cpp</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/qc_buffer_backend/qc_buffer_backend/qc_buffer_plugin.xml
+++ b/qc_buffer_backend/qc_buffer_backend/qc_buffer_plugin.xml
@@ -1,0 +1,9 @@
+<!-- Copyright 2026 Open Source Robotics Foundation, Inc.
+     Licensed under the Apache License, Version 2.0 -->
+<library path="qc_buffer_backend">
+  <class name="qc"
+         type="qc_buffer_backend::QcBufferBackend"
+         base_class_type="rosidl::BufferBackend">
+    <description>Qualcomm backend for buffer serialization with ION/dma-buf HTP-CPU zero-copy</description>
+  </class>
+</library>

--- a/qc_buffer_backend/qc_buffer_backend/src/qc_buffer_backend_plugin.cpp
+++ b/qc_buffer_backend/qc_buffer_backend/src/qc_buffer_backend_plugin.cpp
@@ -1,0 +1,229 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "qc_buffer_backend/qc_buffer_backend.hpp"
+
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cinttypes>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <typeinfo>
+#include <utility>
+
+#include "pluginlib/class_list_macros.hpp"
+#include "qc_buffer/fd_broker.hpp"
+#include "qc_buffer/qc_buffer.hpp"
+#include "qc_buffer/qc_buffer_impl.hpp"
+#include "qc_buffer/rpcmem_loader.hpp"
+#include "qc_buffer_backend_msgs/msg/qc_buffer_descriptor.hpp"
+#include "rcutils/logging_macros.h"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+
+namespace qc_buffer_backend
+{
+
+const rosidl_message_type_support_t *
+QcBufferBackend::get_descriptor_type_support() const
+{
+  return rosidl_typesupport_cpp::get_message_type_support_handle<
+    qc_buffer_backend_msgs::msg::QcBufferDescriptor>();
+}
+
+std::shared_ptr<void>
+QcBufferBackend::create_empty_descriptor() const
+{
+  return std::make_shared<qc_buffer_backend_msgs::msg::QcBufferDescriptor>();
+}
+
+std::shared_ptr<void> QcBufferBackend::create_descriptor_with_endpoint(
+  const void * impl,
+  const rmw_topic_endpoint_info_t & endpoint_info) const
+{
+  (void)endpoint_info;
+
+  auto * qc_impl = dynamic_cast<QcBufferImpl<uint8_t> *>(
+    const_cast<rosidl::BufferImplBase<uint8_t> *>(
+      static_cast<const rosidl::BufferImplBase<uint8_t> *>(impl)));
+  if (!qc_impl) {
+    return nullptr;
+  }
+
+  if (!RpcMemLoader::instance().available()) {
+    return nullptr;
+  }
+
+  const auto & qc = qc_impl->get_qc_buffer();
+  if (!qc || qc->dmabuf_fd() < 0) {
+    return nullptr;
+  }
+
+  auto & broker = FdBroker::instance();
+  if (!broker.running()) {
+    return nullptr;
+  }
+
+  // Broker holds a dup(fd) to keep dma-buf alive until all subscribers have taken it.
+  broker.register_buffer(qc->uid(), qc->dmabuf_fd(), qc->size());
+
+  auto descriptor = std::make_shared<qc_buffer_backend_msgs::msg::QcBufferDescriptor>();
+  descriptor->size = qc_impl->size();
+  descriptor->element_type_name = typeid(uint8_t).name();
+  descriptor->pid = static_cast<int32_t>(getpid());
+  descriptor->vaddr = reinterpret_cast<uint64_t>(qc->data());
+  descriptor->uid = qc->uid();
+  descriptor->dmabuf_fd = qc->dmabuf_fd();
+  descriptor->dmabuf_size = qc->size();
+  descriptor->use_ipc = true;
+  descriptor->ipc_socket_path = broker.socket_path();
+
+  return descriptor;
+}
+
+std::unique_ptr<void, void (*)(void *)> QcBufferBackend::from_descriptor_with_endpoint(
+  const void * descriptor_ptr,
+  const rmw_topic_endpoint_info_t & endpoint_info) const
+{
+  (void)endpoint_info;
+
+  auto make_empty = []() {
+      auto empty = std::make_unique<QcBufferImpl<uint8_t>>();
+      return std::unique_ptr<void, void (*)(void *)>(
+        empty.release(), [](void * p) {
+          delete static_cast<rosidl::BufferImplBase<uint8_t> *>(p);
+        });
+    };
+
+  const auto * descriptor =
+    static_cast<const qc_buffer_backend_msgs::msg::QcBufferDescriptor *>(descriptor_ptr);
+
+  if (descriptor->element_type_name != typeid(uint8_t).name()) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "QcBufferDescriptor element type mismatch: expected %s, got %s; dropping",
+      typeid(uint8_t).name(), descriptor->element_type_name.c_str());
+    return make_empty();
+  }
+
+  if (!descriptor->use_ipc || descriptor->ipc_socket_path.empty()) {
+    RCUTILS_LOG_WARN_ONCE_NAMED(
+      "qc_buffer_backend",
+      "qc descriptor missing IPC socket path; falling back to CPU");
+    return make_empty();
+  }
+
+  // Connect to the publisher's FdBroker socket.
+  int sock = ::socket(AF_UNIX, SOCK_STREAM, 0);
+  if (sock < 0) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "FdBroker client: socket() failed: %s", strerror(errno));
+    return make_empty();
+  }
+
+  struct timeval tv{0, 500'000};
+  ::setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+  ::setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+
+  struct sockaddr_un addr{};
+  addr.sun_family = AF_UNIX;
+  std::strncpy(
+    addr.sun_path, descriptor->ipc_socket_path.c_str(), sizeof(addr.sun_path) - 1);
+
+  if (::connect(sock, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr)) < 0) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "FdBroker client: connect(%s) failed: %s",
+      descriptor->ipc_socket_path.c_str(), strerror(errno));
+    ::close(sock);
+    return make_empty();
+  }
+
+  uint64_t uid = descriptor->uid;
+  if (::send(sock, &uid, sizeof(uid), 0) != static_cast<ssize_t>(sizeof(uid))) {
+    ::close(sock);
+    return make_empty();
+  }
+
+  // Receive status byte + fd via SCM_RIGHTS.
+  uint8_t status = 0;
+  struct iovec iov{&status, 1};
+  union {
+    char buf[CMSG_SPACE(sizeof(int))];
+    struct cmsghdr align;
+  } cmsg_buf{};
+  struct msghdr msg{};
+  msg.msg_iov = &iov;
+  msg.msg_iovlen = 1;
+  msg.msg_control = cmsg_buf.buf;
+  msg.msg_controllen = sizeof(cmsg_buf.buf);
+
+  ssize_t r = ::recvmsg(sock, &msg, 0);
+  ::close(sock);
+
+  if (r <= 0 || status != 0x01) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "FdBroker client: uid %" PRIu64 " not available (status=%u); falling back to CPU",
+      uid, static_cast<unsigned>(status));
+    return make_empty();
+  }
+
+  // If the cmsg buffer was too small, the kernel drops the fd silently.
+  if (msg.msg_flags & MSG_CTRUNC) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "FdBroker client: SCM_RIGHTS control message truncated (MSG_CTRUNC) "
+      "for uid %" PRIu64 "; fd dropped by kernel, falling back to CPU", uid);
+    return make_empty();
+  }
+
+  int received_fd = -1;
+  struct cmsghdr * cmsg = CMSG_FIRSTHDR(&msg);
+  if (cmsg && cmsg->cmsg_level == SOL_SOCKET && cmsg->cmsg_type == SCM_RIGHTS) {
+    std::memcpy(&received_fd, CMSG_DATA(cmsg), sizeof(int));
+  }
+  if (received_fd < 0) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "FdBroker client: SCM_RIGHTS fd missing for uid %" PRIu64,
+      uid);
+    return make_empty();
+  }
+
+  // mmap the received fd into this process's address space.
+  try {
+    auto result = std::make_unique<QcBufferImpl<uint8_t>>(
+      received_fd, descriptor->dmabuf_size, descriptor->size);
+    return std::unique_ptr<void, void (*)(void *)>(
+      result.release(), [](void * p) {
+        delete static_cast<rosidl::BufferImplBase<uint8_t> *>(p);
+      });
+  } catch (const std::exception & e) {
+    RCUTILS_LOG_WARN_NAMED(
+      "qc_buffer_backend",
+      "FdBroker client: QcBufferImpl construction failed: %s", e.what());
+    return make_empty();
+  }
+}
+
+}  // namespace qc_buffer_backend
+
+PLUGINLIB_EXPORT_CLASS(
+  qc_buffer_backend::QcBufferBackend,
+  rosidl::BufferBackend)

--- a/qc_buffer_backend/qc_buffer_backend/test/test_qc_buffer_backend.cpp
+++ b/qc_buffer_backend/qc_buffer_backend/test/test_qc_buffer_backend.cpp
@@ -1,0 +1,236 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <gtest/gtest.h>
+
+#include <unistd.h>
+
+#include <memory>
+#include <string>
+#include <typeinfo>
+
+#include "qc_buffer/fd_broker.hpp"
+#include "qc_buffer/qc_buffer.hpp"
+#include "qc_buffer/qc_buffer_api.hpp"
+#include "qc_buffer/qc_buffer_impl.hpp"
+#include "qc_buffer/rpcmem_loader.hpp"
+#include "qc_buffer_backend/qc_buffer_backend.hpp"
+#include "qc_buffer_backend_msgs/msg/qc_buffer_descriptor.hpp"
+#include "rmw/topic_endpoint_info.h"
+
+using qc_buffer_backend::FdBroker;
+using qc_buffer_backend::QcBuffer;
+using qc_buffer_backend::QcBufferBackend;
+using qc_buffer_backend::QcBufferImpl;
+using qc_buffer_backend::RpcMemLoader;
+
+namespace
+{
+
+/// Build a zeroed endpoint info (no GID information).
+rmw_topic_endpoint_info_t make_endpoint()
+{
+  rmw_topic_endpoint_info_t ep = rmw_get_zero_initialized_topic_endpoint_info();
+  return ep;
+}
+
+}  // namespace
+
+// ── QcBufferBackend basic interface ──────────────────────────────────────────
+
+// Backend type string is "qc".
+TEST(QcBufferBackendTest, BackendTypeIsQc)
+{
+  QcBufferBackend backend;
+  EXPECT_EQ(backend.get_backend_type(), "qc");
+}
+
+// Descriptor type support is non-null.
+TEST(QcBufferBackendTest, DescriptorTypeSupportNonNull)
+{
+  QcBufferBackend backend;
+  EXPECT_NE(backend.get_descriptor_type_support(), nullptr);
+}
+
+// create_empty_descriptor returns a non-null, zero-initialized descriptor.
+TEST(QcBufferBackendTest, CreateEmptyDescriptorNonNull)
+{
+  QcBufferBackend backend;
+  auto desc = backend.create_empty_descriptor();
+  ASSERT_NE(desc, nullptr);
+  const auto * typed =
+    static_cast<const qc_buffer_backend_msgs::msg::QcBufferDescriptor *>(desc.get());
+  EXPECT_EQ(typed->uid, 0u);
+  EXPECT_FALSE(typed->use_ipc);
+}
+
+// ── create_descriptor_with_endpoint ──────────────────────────────────────────
+
+// Returns nullptr for a non-QcBufferImpl impl pointer.
+TEST(QcBufferBackendTest, CreateDescriptorReturnsNullForNonQcImpl)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBufferBackend backend;
+  auto ep = make_endpoint();
+  // nullptr impl must return nullptr immediately.
+  auto desc = backend.create_descriptor_with_endpoint(nullptr, ep);
+  EXPECT_EQ(desc, nullptr);
+}
+
+// Successful path: descriptor is populated with correct fields.
+TEST(QcBufferBackendTest, CreateDescriptorPopulatesFields)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBufferBackend backend;
+  auto ep = make_endpoint();
+
+  QcBufferImpl<uint8_t> impl(32);
+  auto desc_ptr = backend.create_descriptor_with_endpoint(&impl, ep);
+  ASSERT_NE(desc_ptr, nullptr);
+
+  const auto * desc =
+    static_cast<const qc_buffer_backend_msgs::msg::QcBufferDescriptor *>(desc_ptr.get());
+
+  EXPECT_EQ(desc->size, 32u);
+  EXPECT_EQ(desc->element_type_name, std::string(typeid(uint8_t).name()));
+  EXPECT_EQ(desc->pid, static_cast<int32_t>(getpid()));
+  EXPECT_GT(desc->uid, 0u);
+  EXPECT_GE(desc->dmabuf_fd, 0);
+  EXPECT_GT(desc->dmabuf_size, 0u);
+  EXPECT_TRUE(desc->use_ipc);
+  EXPECT_FALSE(desc->ipc_socket_path.empty());
+}
+
+// Descriptor ipc_socket_path contains the current pid.
+TEST(QcBufferBackendTest, CreateDescriptorSocketPathContainsPid)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBufferBackend backend;
+  auto ep = make_endpoint();
+
+  QcBufferImpl<uint8_t> impl(16);
+  auto desc_ptr = backend.create_descriptor_with_endpoint(&impl, ep);
+  ASSERT_NE(desc_ptr, nullptr);
+
+  const auto * desc =
+    static_cast<const qc_buffer_backend_msgs::msg::QcBufferDescriptor *>(desc_ptr.get());
+  EXPECT_NE(
+    desc->ipc_socket_path.find(std::to_string(getpid())),
+    std::string::npos);
+}
+
+// ── from_descriptor_with_endpoint ────────────────────────────────────────────
+
+// Returns empty impl (not null) for descriptor with mismatched element type.
+TEST(QcBufferBackendTest, FromDescriptorReturnsEmptyOnTypeMismatch)
+{
+  QcBufferBackend backend;
+  auto ep = make_endpoint();
+
+  qc_buffer_backend_msgs::msg::QcBufferDescriptor desc;
+  desc.element_type_name = "wrong_type";
+  desc.use_ipc = false;
+
+  auto result = backend.from_descriptor_with_endpoint(&desc, ep);
+  ASSERT_NE(result.get(), nullptr);
+  const auto * impl =
+    static_cast<const rosidl::BufferImplBase<uint8_t> *>(result.get());
+  EXPECT_EQ(impl->size(), 0u);
+}
+
+// Returns empty impl for descriptor without IPC socket path.
+TEST(QcBufferBackendTest, FromDescriptorReturnsEmptyWhenNoSocketPath)
+{
+  QcBufferBackend backend;
+  auto ep = make_endpoint();
+
+  qc_buffer_backend_msgs::msg::QcBufferDescriptor desc;
+  desc.element_type_name = typeid(uint8_t).name();
+  desc.use_ipc = false;
+  desc.ipc_socket_path = "";
+
+  auto result = backend.from_descriptor_with_endpoint(&desc, ep);
+  ASSERT_NE(result.get(), nullptr);
+  const auto * impl =
+    static_cast<const rosidl::BufferImplBase<uint8_t> *>(result.get());
+  EXPECT_EQ(impl->size(), 0u);
+}
+
+// Full roundtrip: create descriptor then reconstruct impl from it.
+TEST(QcBufferBackendTest, RoundTripZeroCopy)
+{
+  if (!RpcMemLoader::instance().available()) {
+    GTEST_SKIP() << "rpcmem not available";
+  }
+  QcBufferBackend backend;
+  auto ep = make_endpoint();
+
+  // Publisher side: allocate and write a known pattern.
+  QcBufferImpl<uint8_t> pub_impl(8);
+  pub_impl.get_qc_buffer()->data()[0] = 0xDE;
+  pub_impl.get_qc_buffer()->data()[7] = 0xAD;
+
+  auto desc_ptr = backend.create_descriptor_with_endpoint(&pub_impl, ep);
+  ASSERT_NE(desc_ptr, nullptr);
+
+  // Subscriber side: reconstruct from descriptor.
+  auto sub_result = backend.from_descriptor_with_endpoint(desc_ptr.get(), ep);
+  ASSERT_NE(sub_result.get(), nullptr);
+
+  const auto * sub_impl =
+    static_cast<const QcBufferImpl<uint8_t> *>(sub_result.get());
+  ASSERT_NE(sub_impl->get_qc_buffer(), nullptr);
+
+  EXPECT_EQ(sub_impl->size(), 8u);
+  EXPECT_EQ(sub_impl->get_backend_type(), "qc");
+  // Same physical memory: subscriber sees the bytes the publisher wrote.
+  EXPECT_EQ(sub_impl->get_qc_buffer()->data()[0], 0xDE);
+  EXPECT_EQ(sub_impl->get_qc_buffer()->data()[7], 0xAD);
+  // dma-buf fd is available for HTP accelerator registration.
+  EXPECT_GE(sub_impl->get_qc_buffer()->dmabuf_fd(), 0);
+}
+
+// Roundtrip with broker miss (stale uid) returns empty impl, not crash.
+TEST(QcBufferBackendTest, FromDescriptorReturnsFallbackOnBrokerMiss)
+{
+  QcBufferBackend backend;
+  auto ep = make_endpoint();
+
+  qc_buffer_backend_msgs::msg::QcBufferDescriptor desc;
+  desc.element_type_name = typeid(uint8_t).name();
+  desc.use_ipc = true;
+  desc.uid = 0xDEADBEEF0ULL;
+  desc.dmabuf_size = 64;
+  desc.size = 64;
+  // Use the current broker socket (broker is running but uid is unknown).
+  desc.ipc_socket_path = FdBroker::instance().socket_path();
+
+  auto result = backend.from_descriptor_with_endpoint(&desc, ep);
+  ASSERT_NE(result.get(), nullptr);
+  const auto * impl =
+    static_cast<const rosidl::BufferImplBase<uint8_t> *>(result.get());
+  EXPECT_EQ(impl->size(), 0u);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/qc_buffer_backend/qc_buffer_backend_msgs/CMakeLists.txt
+++ b/qc_buffer_backend/qc_buffer_backend_msgs/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.20)
+project(qc_buffer_backend_msgs)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/QcBufferDescriptor.msg"
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()

--- a/qc_buffer_backend/qc_buffer_backend_msgs/msg/QcBufferDescriptor.msg
+++ b/qc_buffer_backend/qc_buffer_backend_msgs/msg/QcBufferDescriptor.msg
@@ -1,0 +1,29 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+uint64 size                 # Number of elements (Phase 1: equals byte count since uint8_t)
+string element_type_name    # Type name for validation (e.g. typeid(uint8_t).name())
+
+# Intra-process zero-copy core fields
+int32  pid                  # Publisher process ID; subscriber compares getpid() for same-process
+uint64 vaddr                # Publisher CPU virtual address (valid within the same process)
+uint64 uid                  # Unique per allocation, used for registry lookup and staleness detection
+
+# dma-buf metadata (same-process HTP registration; cross-process transfer in Phase 2)
+int32  dmabuf_fd            # dma-buf file descriptor (directly valid within the same process)
+uint64 dmabuf_size         # Byte size for mapping
+
+# --- Reserved for Phase 2 (cross-process SCM_RIGHTS); not populated in Phase 1 ---
+bool   use_ipc             # Whether cross-process IPC is used (always false in Phase 1)
+string ipc_socket_path     # Phase 2: Unix socket path for passing the fd

--- a/qc_buffer_backend/qc_buffer_backend_msgs/package.xml
+++ b/qc_buffer_backend/qc_buffer_backend_msgs/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>qc_buffer_backend_msgs</name>
+  <version>0.1.0</version>
+  <description>Qualcomm buffer descriptor messages for rosidl::Buffer backend serialization.</description>
+
+  <maintainer email="nasong@qti.qualcomm.com">Na Song</maintainer>
+  <license>Apache-2.0</license>
+  <author email="nasong@qti.qualcomm.com">Na Song</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/qc_buffer_backend/tutorial/README.md
+++ b/qc_buffer_backend/tutorial/README.md
@@ -1,0 +1,31 @@
+# qc_buffer_backend tutorial
+
+A minimal pipeline showing `qc_buffer_backend` HTP–CPU zero-copy: one publisher node and one subscriber node.
+
+- `src/qc_image_publisher.cpp` — allocates a qc-backed buffer, writes it via the CPU pointer, and publishes it on the `qc_image` topic.
+- `src/qc_image_subscriber.cpp` — subscribes to `qc_image`, reads the same memory directly (zero-copy) and prints its dma-buf fd.
+- `launch/qc_buffer_tutorial.launch.py` — loads both nodes into a single `component_container` process.
+
+## Build
+
+```bash
+colcon build --packages-up-to qc_buffer_tutorial
+```
+
+## Run
+
+```bash
+source install/setup.bash
+ros2 launch qc_buffer_tutorial qc_buffer_tutorial.launch.py
+```
+
+Expected output (publisher every 10 frames, subscriber every frame):
+
+```
+[qc_image_publisher]  published 10 images (backend: qc, fd: 42)
+[qc_image_subscriber] image #1: 8x8, 192 bytes, backend=qc, dmabuf_fd=43, first_byte=0 ...
+```
+
+`backend=qc` on the subscriber side confirms the payload was delivered through dma-buf without a copy. The reported `dmabuf_fd` is what an application passes to the HTP accelerator to let it read the same memory. The subscriber receives a fresh fd via SCM_RIGHTS and mmap()s it to the same physical pages the publisher wrote.
+
+If you see `backend=cpu (CPU fallback)` instead, the device does not have `libcdsprpc.so` available.

--- a/qc_buffer_backend/tutorial/qc_buffer_tutorial/CMakeLists.txt
+++ b/qc_buffer_backend/tutorial/qc_buffer_tutorial/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.20)
+project(qc_buffer_tutorial)
+
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(rosidl_runtime_cpp REQUIRED)
+find_package(qc_buffer REQUIRED)
+
+add_library(qc_image_publisher_component SHARED src/qc_image_publisher.cpp)
+target_link_libraries(qc_image_publisher_component
+  rclcpp::rclcpp
+  rclcpp_components::component
+  qc_buffer::qc_buffer
+  rosidl_runtime_cpp::rosidl_runtime_cpp
+  ${sensor_msgs_TARGETS}
+)
+rclcpp_components_register_nodes(qc_image_publisher_component "QcImagePublisher")
+
+add_library(qc_image_subscriber_component SHARED src/qc_image_subscriber.cpp)
+target_link_libraries(qc_image_subscriber_component
+  rclcpp::rclcpp
+  rclcpp_components::component
+  qc_buffer::qc_buffer
+  rosidl_runtime_cpp::rosidl_runtime_cpp
+  ${sensor_msgs_TARGETS}
+)
+rclcpp_components_register_nodes(qc_image_subscriber_component "QcImageSubscriber")
+
+install(TARGETS
+  qc_image_publisher_component
+  qc_image_subscriber_component
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY launch DESTINATION share/${PROJECT_NAME})
+
+ament_package()

--- a/qc_buffer_backend/tutorial/qc_buffer_tutorial/launch/qc_buffer_tutorial.launch.py
+++ b/qc_buffer_backend/tutorial/qc_buffer_tutorial/launch/qc_buffer_tutorial.launch.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Runs the publisher and subscriber as composable nodes in ONE container
+# process, so qc_buffer_backend delivers the payload zero-copy.
+
+import launch
+from launch import LaunchDescription
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+
+
+def generate_launch_description():
+    pub_node = ComposableNode(
+        package='qc_buffer_tutorial',
+        plugin='QcImagePublisher',
+        name='qc_image_publisher',
+    )
+
+    sub_node = ComposableNode(
+        package='qc_buffer_tutorial',
+        plugin='QcImageSubscriber',
+        name='qc_image_subscriber',
+    )
+
+    container = ComposableNodeContainer(
+        name = "container",
+        namespace = "qc_buffer_backend_test",
+        package = "rclcpp_components",
+        executable='component_container',
+        output = "screen",
+        composable_node_descriptions=[pub_node, sub_node]
+    )
+
+    return launch.LaunchDescription([container])

--- a/qc_buffer_backend/tutorial/qc_buffer_tutorial/package.xml
+++ b/qc_buffer_backend/tutorial/qc_buffer_tutorial/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>qc_buffer_tutorial</name>
+  <version>0.1.0</version>
+  <description>Minimal publisher/subscriber tutorial for qc_buffer_backend
+  intra-process HTP-CPU zero-copy.</description>
+
+  <maintainer email="nasong@qti.qualcomm.com">Na Song</maintainer>
+  <license>Apache-2.0</license>
+  <author email="nasong@qti.qualcomm.com">Na Song</author>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>sensor_msgs</depend>
+  <depend>rosidl_runtime_cpp</depend>
+  <depend>qc_buffer</depend>
+
+  <exec_depend>qc_buffer_backend</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/qc_buffer_backend/tutorial/qc_buffer_tutorial/src/qc_image_publisher.cpp
+++ b/qc_buffer_backend/tutorial/qc_buffer_tutorial/src/qc_image_publisher.cpp
@@ -1,0 +1,88 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Minimal publisher demonstrating qc_buffer_backend.
+//
+// It allocates a qc-backed rosidl::Buffer<uint8_t>, fills it directly through
+// the CPU pointer (no copy), and publishes it. When a subscriber lives in the
+// same process, delivery is zero-copy.
+
+#include <chrono>
+#include <memory>
+
+#include "qc_buffer/qc_buffer_api.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+class QcImagePublisher : public rclcpp::Node
+{
+public:
+  explicit QcImagePublisher(const rclcpp::NodeOptions & options)
+  : Node("qc_image_publisher", options), count_(0)
+  {
+    width_ = this->declare_parameter<int>("image_width", 8);
+    height_ = this->declare_parameter<int>("image_height", 8);
+
+    publisher_ = this->create_publisher<sensor_msgs::msg::Image>("qc_image", 10);
+    timer_ = this->create_wall_timer(
+      std::chrono::milliseconds(500),
+      std::bind(&QcImagePublisher::tick, this));
+
+    RCLCPP_INFO(this->get_logger(), "qc_image_publisher started (%dx%d)", width_, height_);
+  }
+
+private:
+  void tick()
+  {
+    const size_t size = static_cast<size_t>(width_) * height_ * 3;
+
+    sensor_msgs::msg::Image msg;
+    // Allocate a qc-backed buffer for the payload.
+    msg.data = qc_buffer_backend::allocate_buffer(size);
+    msg.header.stamp = this->now();
+    msg.header.frame_id = "qc_frame";
+    msg.height = height_;
+    msg.width = width_;
+    msg.encoding = "rgb8";
+    msg.step = width_ * 3;
+
+    // Write directly to the ION/dma-buf memory through the CPU pointer.
+    uint8_t * p = qc_buffer_backend::get_data_ptr(msg.data);
+    if (p != nullptr) {
+      std::fill(p, p + size, static_cast<uint8_t>(count_ % 256));
+    } else {
+      // Not qc-backed (e.g. rpcmem unavailable): fall back to normal access.
+      for (size_t i = 0; i < size; ++i) {
+        msg.data[i] = static_cast<uint8_t>(count_ % 256);
+      }
+    }
+
+    publisher_->publish(msg);
+
+    if (++count_ % 10 == 0) {
+      RCLCPP_INFO(this->get_logger(), "published %zu images (backend: %s, fd: %d)",
+        count_, msg.data.get_backend_type().c_str(),
+        qc_buffer_backend::get_dmabuf_fd(msg.data));
+    }
+  }
+
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  size_t count_;
+  int width_;
+  int height_;
+};
+
+RCLCPP_COMPONENTS_REGISTER_NODE(QcImagePublisher)

--- a/qc_buffer_backend/tutorial/qc_buffer_tutorial/src/qc_image_subscriber.cpp
+++ b/qc_buffer_backend/tutorial/qc_buffer_tutorial/src/qc_image_subscriber.cpp
@@ -1,0 +1,78 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Minimal subscriber demonstrating qc_buffer_backend.
+//
+// It accepts any buffer backend. When the message arrives qc-backed (same
+// process as the publisher), it reads the ION/dma-buf memory directly through
+// the CPU pointer and can hand the dma-buf fd to the HTP for zero-copy access.
+// Otherwise it reads the payload the normal way (CPU fallback).
+
+#include <memory>
+
+#include "qc_buffer/qc_buffer_api.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+class QcImageSubscriber : public rclcpp::Node
+{
+public:
+  explicit QcImageSubscriber(const rclcpp::NodeOptions & options)
+  : Node("qc_image_subscriber", options), count_(0)
+  {
+    // Accept whatever backend the publisher used (qc when co-located, cpu
+    // otherwise).
+    rclcpp::SubscriptionOptions sub_opts;
+    sub_opts.acceptable_buffer_backends = "any";
+
+    subscription_ = this->create_subscription<sensor_msgs::msg::Image>(
+      "qc_image", 10,
+      std::bind(&QcImageSubscriber::on_image, this, std::placeholders::_1),
+      sub_opts);
+
+    RCLCPP_INFO(this->get_logger(), "qc_image_subscriber started");
+  }
+
+private:
+  void on_image(const sensor_msgs::msg::Image::SharedPtr msg)
+  {
+    ++count_;
+    const std::string backend = msg->data.get_backend_type();
+
+    if (backend == "qc") {
+      // Zero-copy: read the same ION memory the publisher wrote.
+      const int fd = qc_buffer_backend::get_dmabuf_fd(msg->data);
+      uint8_t * p = qc_buffer_backend::get_data_ptr(msg->data);
+      const uint8_t first = (p != nullptr && msg->data.size() > 0) ? p[0] : 0;
+
+      RCLCPP_INFO(this->get_logger(),
+        "image #%zu: %ux%u, %zu bytes, backend=qc, dmabuf_fd=%d, first_byte=%u "
+        "(pass fd to the HTP accelerator for zero-copy)",
+        count_, msg->width, msg->height, msg->data.size(), fd, first);
+    } else {
+      // CPU fallback: read the payload the normal way.
+      const std::vector<uint8_t> & data = msg->data;
+      const uint8_t first = data.empty() ? 0 : data[0];
+      RCLCPP_INFO(this->get_logger(),
+        "image #%zu: %ux%u, %zu bytes, backend=%s (CPU fallback), first_byte=%u",
+        count_, msg->width, msg->height, msg->data.size(), backend.c_str(), first);
+    }
+  }
+
+  rclcpp::Subscription<sensor_msgs::msg::Image>::SharedPtr subscription_;
+  size_t count_;
+};
+
+RCLCPP_COMPONENTS_REGISTER_NODE(QcImageSubscriber)


### PR DESCRIPTION
## Description

This pull request introduces `qc_buffer_backend`, a pluggable `rosidl::Buffer<T>` storage backend for Qualcomm platforms that enables **HTP-CPU zero-copy** message delivery in ROS2 pipelines.

### Is this user-facing behavior change?

NA.

### Did you use Generative AI?

Yes.

### Additional Information

More details can be found on `qc_buffer_backend_design.md` and `README.md`.
