### PR TITLE
Fix process-wide CUDA allocation pool

### DIFF
--- a/cuda_buffer_backend/cuda_buffer/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(CUDAToolkit REQUIRED)
 
 add_library(${PROJECT_NAME} SHARED
   src/cuda_buffer.cpp
+  src/cuda_buffer_impl.cpp
   src/cuda_buffer_ipc_manager.cpp
   src/cuda_memory_pool.cpp
   src/host_endpoint_manager.cpp

--- a/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_impl.hpp
+++ b/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_buffer_impl.hpp
@@ -25,12 +25,17 @@
 #include "cuda_buffer/cuda_buffer.hpp"
 #include "cuda_buffer/cuda_error.hpp"
 #include "cuda_buffer/cuda_memory_pool.hpp"
+#include "cuda_buffer/visibility_control.h"
 #include "rosidl_buffer/buffer.hpp"
 #include "rosidl_buffer/buffer_impl_base.hpp"
 #include "rosidl_buffer/cpu_buffer_impl.hpp"
 
 namespace cuda_buffer_backend
 {
+
+/// Process-wide VMM allocation pool. Defined out-of-line so backend plugins
+/// and application DSOs resolve allocations through the same pool instance.
+CUDA_BUFFER_PUBLIC std::shared_ptr<CudaMemoryPool> get_or_create_global_pool();
 
 // Process-wide stream for internal ops (clone, to_cpu, resize).
 // Intentionally leaked; destroyed by cudaDeviceReset in ~CudaMemoryPool.
@@ -156,15 +161,7 @@ public:
 
   static std::shared_ptr<CudaMemoryPool> get_or_create_global_pool()
   {
-    static std::shared_ptr<CudaMemoryPool> global_pool = [] {
-        auto pool = std::make_shared<CudaMemoryPool>();
-        const CUresult r = pool->create();
-        if (r != CUDA_SUCCESS) {
-          throw CudaError(__FILE__, __LINE__, "CudaMemoryPool::create", r);
-        }
-        return pool;
-      }();
-    return global_pool;
+    return cuda_buffer_backend::get_or_create_global_pool();
   }
 
   static bool is_pool_ipc_capable()

--- a/cuda_buffer_backend/cuda_buffer/src/cuda_buffer_impl.cpp
+++ b/cuda_buffer_backend/cuda_buffer/src/cuda_buffer_impl.cpp
@@ -1,0 +1,35 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cuda_buffer/cuda_buffer_impl.hpp"
+
+#include <memory>
+
+namespace cuda_buffer_backend
+{
+
+std::shared_ptr<CudaMemoryPool> get_or_create_global_pool()
+{
+  static std::shared_ptr<CudaMemoryPool> global_pool = [] {
+      auto pool = std::make_shared<CudaMemoryPool>();
+      const CUresult result = pool->create();
+      if (result != CUDA_SUCCESS) {
+        throw CudaError(__FILE__, __LINE__, "CudaMemoryPool::create", result);
+      }
+      return pool;
+    }();
+  return global_pool;
+}
+
+}  // namespace cuda_buffer_backend

--- a/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
@@ -101,6 +101,24 @@ if(BUILD_TESTING)
   rclcpp_components_register_nodes(cuda_image_publisher_component
     "CudaImagePublisher")
 
+  ament_auto_add_library(cuda_image_dso_publisher_component SHARED
+    test/src/cuda_image_dso_publisher_node.cpp
+  )
+  set_target_properties(cuda_image_dso_publisher_component PROPERTIES
+    CXX_VISIBILITY_PRESET hidden
+    VISIBILITY_INLINES_HIDDEN YES
+  )
+  target_link_libraries(cuda_image_dso_publisher_component
+    cuda_buffer::cuda_buffer
+    CUDA::cudart
+    rclcpp::rclcpp
+    rclcpp_components::component
+    ${sensor_msgs_TARGETS}
+    rosidl_runtime_cpp::rosidl_runtime_cpp
+  )
+  rclcpp_components_register_nodes(cuda_image_dso_publisher_component
+    "CudaImageDsoPublisher")
+
   ament_auto_add_library(cuda_image_subscriber_component SHARED
     test/src/cuda_image_subscriber_node.cpp
   )
@@ -148,6 +166,11 @@ if(BUILD_TESTING)
 
   add_launch_test(test/test_cuda_image_multiprocess_fastrtps_launch.py
     TARGET test_cuda_image_multiprocess_fastrtps_launch
+    TIMEOUT 45
+  )
+
+  add_launch_test(test/test_cuda_image_pool_dso_fastrtps_launch.py
+    TARGET test_cuda_image_pool_dso_fastrtps_launch
     TIMEOUT 45
   )
 

--- a/cuda_buffer_backend/cuda_buffer_backend/package.xml
+++ b/cuda_buffer_backend/cuda_buffer_backend/package.xml
@@ -27,6 +27,7 @@
   <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
+  <test_depend>launch_testing_ros</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rclcpp_components</test_depend>
   <test_depend>sensor_msgs</test_depend>

--- a/cuda_buffer_backend/cuda_buffer_backend/test/src/cuda_image_dso_publisher_node.cpp
+++ b/cuda_buffer_backend/cuda_buffer_backend/test/src/cuda_image_dso_publisher_node.cpp
@@ -1,0 +1,99 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "cuda_buffer/cuda_buffer_api.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "sensor_msgs/msg/image.hpp"
+
+class CudaImageDsoPublisher : public rclcpp::Node
+{
+public:
+  explicit CudaImageDsoPublisher(const rclcpp::NodeOptions & options)
+  : Node("cuda_image_dso_publisher", options)
+  {
+    CUDA_CHECK(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
+    publisher_ = create_publisher<sensor_msgs::msg::Image>("test_cuda_image_dso", 10);
+    timer_ = create_wall_timer(
+      std::chrono::milliseconds(100),
+      std::bind(&CudaImageDsoPublisher::publish_next, this));
+  }
+
+  ~CudaImageDsoPublisher() override
+  {
+    if (stream_ != nullptr) {
+      (void)cudaStreamSynchronize(stream_);
+      (void)cudaStreamDestroy(stream_);
+    }
+  }
+
+private:
+  static constexpr std::size_t kMessages = 5;
+  static constexpr std::size_t kPayloadSize = 4096;
+
+  static std::uint8_t pattern_for(std::size_t sequence)
+  {
+    return static_cast<std::uint8_t>((sequence * 37u + 11u) & 0xffu);
+  }
+
+  void publish_next()
+  {
+    if (sequence_ >= kMessages) {
+      timer_->cancel();
+      return;
+    }
+    if (publisher_->get_subscription_count() == 0u) {
+      return;
+    }
+
+    const std::size_t sequence = sequence_ + 1u;
+    const std::uint8_t pattern = pattern_for(sequence);
+
+    sensor_msgs::msg::Image msg;
+    msg.header.stamp = now();
+    msg.header.frame_id = "cuda_pool_dso_" + std::to_string(sequence);
+    msg.height = 16;
+    msg.width = 256;
+    msg.encoding = "mono8";
+    msg.is_bigendian = 0;
+    msg.step = 256;
+    msg.data = cuda_buffer_backend::allocate_buffer(kPayloadSize);
+
+    {
+      auto write_handle = cuda_buffer_backend::from_output_buffer(msg.data, stream_);
+      CUDA_CHECK(cudaMemsetAsync(write_handle.get_ptr(), pattern, kPayloadSize, stream_));
+    }
+
+    publisher_->publish(msg);
+    sequence_ = sequence;
+    RCLCPP_INFO(
+      get_logger(), "DSO_PUBLISH_RESULT message=%zu backend=%s pattern=%u",
+      sequence_, msg.data.get_backend_type().c_str(), static_cast<unsigned>(pattern));
+  }
+
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  cudaStream_t stream_{nullptr};
+  std::size_t sequence_{0};
+};
+
+RCLCPP_COMPONENTS_REGISTER_NODE(CudaImageDsoPublisher)

--- a/cuda_buffer_backend/cuda_buffer_backend/test/src/cuda_image_subscriber_node.cpp
+++ b/cuda_buffer_backend/cuda_buffer_backend/test/src/cuda_image_subscriber_node.cpp
@@ -14,8 +14,10 @@
 
 #include <cuda_runtime.h>
 
+#include <cstdint>
 #include <cstring>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "rclcpp/rclcpp.hpp"
@@ -35,12 +37,18 @@ public:
     validation_passed_(true)
   {
     this->declare_parameter<std::string>("expected_backend", "cuda");
+    this->declare_parameter<std::string>("acceptable_buffer_backends", "any");
+    this->declare_parameter<bool>("validate_sequence_pattern", false);
     expected_backend_ = this->get_parameter("expected_backend").as_string();
+    acceptable_buffer_backends_ =
+      this->get_parameter("acceptable_buffer_backends").as_string();
+    validate_sequence_pattern_ =
+      this->get_parameter("validate_sequence_pattern").as_bool();
 
     cudaStreamCreate(&stream_);
 
     rclcpp::SubscriptionOptions sub_opts;
-    sub_opts.acceptable_buffer_backends = "any";
+    sub_opts.acceptable_buffer_backends = acceptable_buffer_backends_;
     subscription_ = this->create_subscription<sensor_msgs::msg::Image>(
       "test_cuda_image", 10,
       std::bind(&CudaImageSubscriber::image_callback, this, std::placeholders::_1),
@@ -79,9 +87,11 @@ private:
     bool metadata_valid = true;
     bool backend_valid = true;
     bool content_valid = true;
-    size_t expected_size = msg->width * msg->height * 3;
+    const size_t channels = validate_sequence_pattern_ ? 1u : 3u;
+    const size_t expected_size = msg->width * msg->height * channels;
+    const char * expected_encoding = validate_sequence_pattern_ ? "mono8" : "rgb8";
 
-    if (msg->encoding != "rgb8") {
+    if (msg->encoding != expected_encoding) {
       RCLCPP_ERROR(this->get_logger(), "Wrong encoding: %s",
                    msg->encoding.c_str());
       metadata_valid = false;
@@ -91,6 +101,21 @@ private:
       RCLCPP_ERROR(this->get_logger(), "Wrong data size: %zu (expected %zu)",
                    msg->data.size(), expected_size);
       metadata_valid = false;
+    }
+
+    uint8_t expected_value = 0;
+    if (validate_sequence_pattern_) {
+      const std::string expected_frame_id =
+        "cuda_pool_dso_" + std::to_string(received_count_);
+      expected_value = static_cast<uint8_t>((received_count_ * 37u + 11u) & 0xffu);
+      if (msg->header.frame_id != expected_frame_id || msg->encoding != "mono8" ||
+        msg->height != 16u || msg->width != 256u || msg->step != 256u ||
+        msg->data.size() != 4096u)
+      {
+        RCLCPP_ERROR(
+          this->get_logger(), "Wrong DSO regression metadata for image #%u", received_count_);
+        metadata_valid = false;
+      }
     }
 
     const std::string backend_type = msg->data.get_backend_type();
@@ -120,9 +145,12 @@ private:
       content_valid = false;
     }
 
-    if (!cpu_data.empty() && metadata_valid && backend_valid) {
-      uint8_t expected_val = cpu_data[0];
-      for (size_t i = 1; i < cpu_data.size(); ++i) {
+    if (cpu_data.empty()) {
+      content_valid = false;
+    } else if (metadata_valid && backend_valid) {
+      const uint8_t expected_val = validate_sequence_pattern_ ? expected_value : cpu_data[0];
+      const size_t first_index = validate_sequence_pattern_ ? 0u : 1u;
+      for (size_t i = first_index; i < cpu_data.size(); ++i) {
         if (cpu_data[i] != expected_val) {
           RCLCPP_ERROR(this->get_logger(),
             "Content corruption at byte %zu: expected 0x%02x, got 0x%02x",
@@ -197,6 +225,8 @@ private:
   uint32_t received_count_;
   bool validation_passed_;
   std::string expected_backend_;
+  std::string acceptable_buffer_backends_;
+  bool validate_sequence_pattern_;
 };
 
 RCLCPP_COMPONENTS_REGISTER_NODE(CudaImageSubscriber)

--- a/cuda_buffer_backend/cuda_buffer_backend/test/test_cuda_image_pool_dso_fastrtps_launch.py
+++ b/cuda_buffer_backend/cuda_buffer_backend/test/test_cuda_image_pool_dso_fastrtps_launch.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.descriptions import ComposableNode
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+from launch_testing_ros.actions import EnableRmwIsolation
+import pytest
+import rclpy
+from std_msgs.msg import Bool, UInt32
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    """Generate a deterministic cross-DSO CUDA pool regression test."""
+    test_domain_id = str(100 + os.getpid() % 100)
+
+    publisher_container = ComposableNodeContainer(
+        name='cuda_image_dso_publisher_container',
+        namespace='',
+        package='rclcpp_components',
+        executable='component_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='cuda_buffer_backend',
+                plugin='CudaImageDsoPublisher',
+                name='cuda_image_dso_publisher',
+            ),
+        ],
+        output='screen',
+    )
+
+    subscriber_container = ComposableNodeContainer(
+        name='cuda_image_dso_subscriber_container',
+        namespace='',
+        package='rclcpp_components',
+        executable='component_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='cuda_buffer_backend',
+                plugin='CudaImageSubscriber',
+                name='cuda_image_dso_subscriber',
+                parameters=[{
+                    'expected_backend': 'cuda',
+                    'acceptable_buffer_backends': 'cuda',
+                    'validate_sequence_pattern': True,
+                }],
+                remappings=[
+                    ('test_cuda_image', 'test_cuda_image_dso'),
+                    ('subscriber_count', 'cuda_image_dso_subscriber_count'),
+                    ('validation_result', 'cuda_image_dso_validation'),
+                    ('backend_validation', 'cuda_image_dso_backend_validation'),
+                    ('content_validation', 'cuda_image_dso_content_validation'),
+                    ('metadata_validation', 'cuda_image_dso_metadata_validation'),
+                ],
+            ),
+        ],
+        output='screen',
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp'),
+        SetEnvironmentVariable('ROS_DOMAIN_ID', test_domain_id),
+        EnableRmwIsolation(),
+        subscriber_container,
+        publisher_container,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+class TestCudaImagePoolDsoFastRTPS(unittest.TestCase):
+    """Verify CUDA descriptor transport across publisher-side DSOs."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('test_cuda_image_pool_dso_fastrtps')
+        self.received_count = 0
+        self.validation_count = 0
+        self.backend_validation_count = 0
+        self.content_validation_count = 0
+        self.metadata_validation_count = 0
+        self.all_valid = True
+
+        self.node.create_subscription(
+            UInt32, 'cuda_image_dso_subscriber_count', self._count_cb, 10)
+        self.node.create_subscription(
+            Bool, 'cuda_image_dso_validation', self._validation_cb, 10)
+        self.node.create_subscription(
+            Bool, 'cuda_image_dso_backend_validation', self._backend_cb, 10)
+        self.node.create_subscription(
+            Bool, 'cuda_image_dso_content_validation', self._content_cb, 10)
+        self.node.create_subscription(
+            Bool, 'cuda_image_dso_metadata_validation', self._metadata_cb, 10)
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def _count_cb(self, msg):
+        self.received_count = msg.data
+
+    def _validation_cb(self, msg):
+        self.validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _backend_cb(self, msg):
+        self.backend_validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _content_cb(self, msg):
+        self.content_validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _metadata_cb(self, msg):
+        self.metadata_validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _complete(self):
+        return (
+            self.received_count >= 5 and
+            self.validation_count >= 5 and
+            self.backend_validation_count >= 5 and
+            self.content_validation_count >= 5 and
+            self.metadata_validation_count >= 5
+        )
+
+    def test_five_cuda_messages_validate(self):
+        """Require an explicit successful validation for every CUDA message."""
+        deadline = time.monotonic() + 30.0
+        while not self._complete() and time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.assertTrue(
+            self._complete(),
+            'Did not observe five complete validations: '
+            f'received={self.received_count}, validation={self.validation_count}, '
+            f'backend={self.backend_validation_count}, '
+            f'content={self.content_validation_count}, '
+            f'metadata={self.metadata_validation_count}',
+        )
+        self.assertTrue(self.all_valid, 'At least one CUDA DSO validation failed')
+
+
+@launch_testing.post_shutdown_test()
+class TestCudaImagePoolDsoFastRTPSShutdown(unittest.TestCase):
+    """Check that both component containers shut down cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info,
+            allowable_exit_codes=[0, -2, -15],
+        )


### PR DESCRIPTION
## Description

  Fixes process-wide CUDA allocation-pool sharing across shared libraries.

  Previously, the CUDA buffer pool was defined as a function-local static in an inline function. This could create separate pool instances in different DSOs within the same process. A publisher component
  could register an allocation in one pool while the dynamically loaded serialization plugin searched another, causing CUDA descriptor serialization to fail or fall back to a CPU buffer.

  This pull request:

  - Moves the global CUDA buffer-pool accessor out of line and exports it from the `cuda_buffer` shared library.
  - Ensures publisher components and serialization plugins use the same process-wide pool instance.
  - Adds a standalone `CudaImageDsoPublisher` test component built with hidden symbol visibility.
  - Adds an inter-process Fast DDS regression test that:
    - Publishes five asynchronously initialized CUDA-backed messages.
    - Loads the publisher component and serialization plugin from separate DSOs.
    - Verifies the received backend is `cuda` before constructing a read handle.
    - Validates message metadata and payload contents.
    - Fails on CPU fallback, corrupted data, missing messages, or missing validation results.
  - Leaves the existing CUDA image publisher test component unchanged.


  ### Is this user-facing behavior change?

  Yes. CUDA-backed messages published across process boundaries now remain CUDA-backed when allocation and serialization occur in different shared libraries within the publisher process. This prevents
  unexpected CPU fallback and preserves the requested CUDA transport behavior.

