### PR TITLE
Add support for sensor_msgs/Image in torch_conversions

### DIFF
--- a/torch_conversions/README.md
+++ b/torch_conversions/README.md
@@ -1,7 +1,7 @@
 # torch_conversions (DLPack-aligned)
 
-Header-only helper library that converts between a DLPack-shaped ROS 2
-message (`tensor_msgs/ExperimentalTensor`) and an `at::Tensor`, riding on top of
+Header-only helper library that converts between DLPack-shaped ROS 2
+messages (`tensor_msgs/ExperimentalTensor` and native `sensor_msgs/Image`) and an `at::Tensor`, riding on top of
 whichever `rosidl::Buffer` storage backend is registered at runtime.
 
 The message schema follows [DLPack](https://dmlc.github.io/dlpack/latest/)
@@ -18,7 +18,7 @@ and interoperate over the wire without re-encoding shape / dtype metadata.
 | Package | Description |
 |---|---|
 | `tensor_msgs` | `ExperimentalTensor.msg` definition: DLPack-aligned `{dtype_code, dtype_bits, dtype_lanes}`, `shape[]`, `strides[]`, `byte_offset`, `data[]`. |
-| `torch_conversions` | Header-only library: allocation, `at::Tensor` ↔ `ExperimentalTensor.msg` conversion, DLPack export, and CUDA stream helpers. |
+| `torch_conversions` | Header-only library: allocation, `at::Tensor` ↔ `ExperimentalTensor.msg` or native `sensor_msgs/Image` conversion, DLPack export, and CUDA stream helpers. |
 
 The `uint8[] data` field maps to `rosidl::Buffer<uint8_t>`,
 so storage and transport are delegated to whichever buffer backend is
@@ -120,6 +120,65 @@ publisher_->publish(std::move(msg));
 `to_tensor_msg(t)` allocates a message, copies tensor data into `msg.data`,
 and updates shape / strides / dtype metadata to match `t`. Use
 `to_tensor_msg(*msg, t)` when you want to reuse a pre-sized message buffer.
+
+## Native `sensor_msgs/Image`
+
+The same buffer-backed conversion path supports packed, byte-oriented native
+image messages. `Image.data` is a `rosidl::Buffer<uint8_t>`, so requesting CUDA
+storage places the pixels in the CUDA buffer backend while preserving the
+standard ROS image metadata and wire type.
+
+```cpp
+#include "sensor_msgs/image_encodings.hpp"
+#include "torch_conversions/torch_conversions.hpp"
+
+auto guard = torch_conversions::set_stream();
+
+// Initializes height, width, encoding, endianness, step, and an exact-size
+// data allocation. CUDA is selected explicitly here.
+auto msg = torch_conversions::allocate_image_msg(
+  height, width, sensor_msgs::image_encodings::RGB8, c10::kCUDA);
+
+// Copy an existing HWC uint8 tensor into Image.data. This is stream-ordered;
+// the conversion does not synchronize the CUDA device or stream.
+torch_conversions::to_image_msg(*msg, source_hwc);
+publisher_->publish(std::move(msg));
+```
+
+A subscriber obtains a tensor from the standard Image fields:
+
+```cpp
+void cb(const sensor_msgs::msg::Image::ConstSharedPtr msg)
+{
+  auto guard = torch_conversions::set_stream();
+
+  // HWC shape and row stride are derived from height, width, encoding, and
+  // step. false requests a zero-copy read-only view.
+  at::Tensor input =
+    torch_conversions::from_input_image_msg(*msg, /*clone=*/false);
+  at::Tensor output = resize(input);
+}
+```
+
+The Image API consists of:
+
+- `allocate_image_msg(height, width, encoding, device)` for initialized CPU or
+  CUDA-backed storage.
+- `from_output_image_msg(msg)` for a writable HWC tensor view used by producers.
+- `from_input_image_msg(msg, clone)` for subscriber input. With `clone=false`,
+  the CUDA read handle and event dependency remain attached to the tensor
+  lifetime and no pixel copy is made.
+- `to_image_msg(msg, tensor)` to copy into an existing allocation without
+  changing its header or image metadata, and `to_image_msg(tensor, encoding)`
+  to allocate and copy in one call.
+
+Conversions do not call `cudaDeviceSynchronize` or `cudaStreamSynchronize`.
+CUDA ReadHandle and WriteHandle objects keep storage and stream-event ordering
+alive until the corresponding tensor view is destroyed. The current bridge
+accepts packed byte encodings such as `mono8`, `rgb8`, `bgr8`, `rgba8`, Bayer8,
+YUV422, and `8UC`/`8SC`. It rejects planar formats, non-byte encodings, a step
+smaller than the packed row size, or data shorter than `height * step` with a
+descriptive exception. Row padding is preserved through tensor strides.
 
 ## License
 

--- a/torch_conversions/torch_conversions/CMakeLists.txt
+++ b/torch_conversions/torch_conversions/CMakeLists.txt
@@ -11,6 +11,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_buffer REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(tensor_msgs REQUIRED)
 find_package(rmw REQUIRED)
 find_package(rcutils REQUIRED)
@@ -40,6 +41,7 @@ target_link_libraries(${PROJECT_NAME}
     rosidl_buffer::rosidl_buffer
     rmw::rmw
     rcutils::rcutils
+    ${sensor_msgs_TARGETS}
     ${tensor_msgs_TARGETS}
 )
 
@@ -66,7 +68,7 @@ install(
 
 ament_export_targets(${PROJECT_NAME})
 ament_export_dependencies(
-  libtorch_vendor rosidl_buffer tensor_msgs rmw rcutils)
+  libtorch_vendor rosidl_buffer sensor_msgs tensor_msgs rmw rcutils)
 if(_torch_has_cuda AND CUDAToolkit_FOUND)
   ament_export_dependencies(CUDAToolkit)
 endif()
@@ -92,6 +94,7 @@ if(BUILD_TESTING)
       ${PROJECT_NAME}
       ${TORCH_LIBRARIES}
       rosidl_buffer::rosidl_buffer
+      ${sensor_msgs_TARGETS}
       ${tensor_msgs_TARGETS}
     )
     if(_torch_has_cuda AND CUDAToolkit_FOUND)

--- a/torch_conversions/torch_conversions/include/torch_conversions/torch_conversions.hpp
+++ b/torch_conversions/torch_conversions/include/torch_conversions/torch_conversions.hpp
@@ -21,8 +21,10 @@
 #include <rcutils/logging_macros.h>
 #include <torch/torch.h>
 
+#include <algorithm>
 #include <cstdint>
 #include <cstring>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <stdexcept>
@@ -31,6 +33,8 @@
 #include <vector>
 
 #include "rosidl_buffer/buffer.hpp"
+#include "sensor_msgs/image_encodings.hpp"
+#include "sensor_msgs/msg/image.hpp"
 #include "tensor_msgs/msg/experimental_tensor.hpp"
 
 #if __has_include("cuda_buffer/cuda_buffer_api.hpp")
@@ -44,6 +48,7 @@ namespace torch_conversions
 {
 
 using TensorMsg = tensor_msgs::msg::ExperimentalTensor;
+using ImageMsg = sensor_msgs::msg::Image;
 
 namespace detail
 {
@@ -170,6 +175,84 @@ inline int64_t numel_of(const std::vector<int64_t> & shape)
     n *= d;
   }
   return n;
+}
+
+struct ImageMetadata
+{
+  std::vector<int64_t> shape;
+  std::vector<int64_t> strides;
+  at::ScalarType dtype;
+  size_t byte_count;
+};
+
+inline size_t checked_multiply(size_t lhs, size_t rhs, const char * context)
+{
+  if (rhs != 0 && lhs > std::numeric_limits<size_t>::max() / rhs) {
+    throw std::runtime_error(
+            std::string("torch_conversions::") + context + ": image size overflows size_t");
+  }
+  return lhs * rhs;
+}
+
+/// Resolve native Image metadata into an HWC torch view.
+/// Only byte-oriented packed encodings are supported because PyTorch does
+/// not have a portable dtype corresponding to every ROS image encoding.
+inline ImageMetadata image_metadata(const ImageMsg & msg, const char * context)
+{
+  if (msg.encoding.empty()) {
+    throw std::runtime_error(
+            std::string("torch_conversions::") + context + ": Image.encoding is empty");
+  }
+  if (sensor_msgs::image_encodings::isPlanar(msg.encoding)) {
+    throw std::runtime_error(
+            std::string("torch_conversions::") + context +
+            ": planar Image encoding " + msg.encoding + " cannot be represented as HWC");
+  }
+
+  int channels;
+  int bits;
+  try {
+    channels = sensor_msgs::image_encodings::numChannels(msg.encoding);
+    bits = sensor_msgs::image_encodings::bitDepth(msg.encoding);
+  } catch (const std::runtime_error & error) {
+    throw std::runtime_error(
+            std::string("torch_conversions::") + context + ": " + error.what());
+  }
+  if (channels <= 0) {
+    throw std::runtime_error(
+            std::string("torch_conversions::") + context +
+            ": encoding has a non-positive channel count");
+  }
+  if (bits != 8) {
+    throw std::runtime_error(
+            std::string("torch_conversions::") + context + ": Image encoding " +
+            msg.encoding + " has " + std::to_string(bits) +
+            "-bit channels; only byte-oriented encodings are supported");
+  }
+
+  const bool signed_bytes = msg.encoding.rfind("8SC", 0) == 0;
+  const size_t packed_row = checked_multiply(
+    static_cast<size_t>(msg.width), static_cast<size_t>(channels), context);
+  if (msg.step < packed_row) {
+    throw std::runtime_error(
+            std::string("torch_conversions::") + context + ": Image.step (" +
+            std::to_string(msg.step) + ") is smaller than the packed row size (" +
+            std::to_string(packed_row) + ")");
+  }
+  const size_t byte_count = checked_multiply(
+    static_cast<size_t>(msg.height), static_cast<size_t>(msg.step), context);
+  if (msg.data.size() < byte_count) {
+    throw std::runtime_error(
+            std::string("torch_conversions::") + context + ": Image.data has " +
+            std::to_string(msg.data.size()) + " bytes, but height * step requires " +
+            std::to_string(byte_count));
+  }
+
+  return ImageMetadata{
+    {static_cast<int64_t>(msg.height), static_cast<int64_t>(msg.width), channels},
+    {static_cast<int64_t>(msg.step), channels, 1},
+    signed_bytes ? at::kChar : at::kByte,
+    byte_count};
 }
 
 #ifdef TORCH_CONVERSIONS_HAS_CUDA
@@ -386,6 +469,118 @@ inline DLManagedTensor * make_output_dlpack(TensorMsg & msg)
 
 #endif  // TORCH_CONVERSIONS_HAS_CUDA
 
+inline void populate_image_dl_tensor(
+  DLManagedTensor & dlm,
+  const ImageMetadata & metadata,
+  const DlpackContext & ctx,
+  void * data_ptr,
+  int32_t dev_type,
+  int32_t dev_id)
+{
+  dlm.dl_tensor.data = data_ptr;
+  dlm.dl_tensor.device = DLDevice{static_cast<DLDeviceType>(dev_type), dev_id};
+  dlm.dl_tensor.ndim = static_cast<int32_t>(ctx.shape.size());
+  dlm.dl_tensor.dtype = dl_dtype_from_scalar(metadata.dtype);
+  dlm.dl_tensor.shape = const_cast<int64_t *>(ctx.shape.data());
+  dlm.dl_tensor.strides = const_cast<int64_t *>(ctx.strides.data());
+  dlm.dl_tensor.byte_offset = 0;
+}
+
+/// Export a read-only HWC DLPack view over Image.data.
+inline DLManagedTensor * make_input_image_dlpack(
+  const ImageMsg & msg
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+  , cudaStream_t consumer_stream = nullptr
+#endif
+)
+{
+  const auto metadata = image_metadata(msg, "from_input_image_msg");
+  auto ctx = std::make_unique<DlpackContext>();
+  ctx->shape = metadata.shape;
+  ctx->strides = metadata.strides;
+
+  void * data_ptr = nullptr;
+  int32_t dev_type = kDLCPU;
+  int32_t dev_id = 0;
+  const std::string & backend = msg.data.get_backend_type();
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+  if (backend == "cuda") {
+    const auto * cuda_impl =
+      dynamic_cast<const cuda_buffer_backend::CudaBufferImpl<uint8_t> *>(
+      msg.data.get_impl());
+    if (!cuda_impl) {
+      throw std::runtime_error(
+              "torch_conversions::from_input_image_msg: cuda backend but not CudaBufferImpl");
+    }
+    ctx->rh = std::make_shared<cuda_buffer_backend::ReadHandle>(
+      cuda_impl->get_cuda_buffer().get_read_handle(consumer_stream));
+    data_ptr = const_cast<void *>(static_cast<const void *>(ctx->rh->get_ptr()));
+    dev_type = kDLCUDA;
+    dev_id = cuda_impl->get_device_id();
+  } else  // NOLINT(readability/braces)
+#endif
+  if (backend == "cpu") {
+    data_ptr = const_cast<void *>(static_cast<const void *>(msg.data.data()));
+  } else {
+    throw std::runtime_error(
+            "torch_conversions::from_input_image_msg: unsupported backend " + backend);
+  }
+
+  auto * dlm = new DLManagedTensor;
+  populate_image_dl_tensor(*dlm, metadata, *ctx, data_ptr, dev_type, dev_id);
+  dlm->manager_ctx = ctx.release();
+  dlm->deleter = dlpack_deleter;
+  return dlm;
+}
+
+/// Export a writable HWC DLPack view over Image.data.
+inline DLManagedTensor * make_output_image_dlpack(
+  ImageMsg & msg
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+  , cudaStream_t consumer_stream = nullptr
+#endif
+)
+{
+  const auto metadata = image_metadata(msg, "from_output_image_msg");
+  auto ctx = std::make_unique<DlpackContext>();
+  ctx->shape = metadata.shape;
+  ctx->strides = metadata.strides;
+
+  void * data_ptr = nullptr;
+  int32_t dev_type = kDLCPU;
+  int32_t dev_id = 0;
+  const std::string & backend = msg.data.get_backend_type();
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+  if (backend == "cuda") {
+    auto * cuda_impl = const_cast<cuda_buffer_backend::CudaBufferImpl<uint8_t> *>(
+      dynamic_cast<const cuda_buffer_backend::CudaBufferImpl<uint8_t> *>(
+        msg.data.get_impl()));
+    if (!cuda_impl) {
+      throw std::runtime_error(
+              "torch_conversions::from_output_image_msg: cuda backend but not CudaBufferImpl");
+    }
+    cuda_impl->set_stream(consumer_stream);
+    ctx->wh = std::make_shared<cuda_buffer_backend::WriteHandle>(
+      cuda_impl->get_cuda_buffer().get_write_handle(consumer_stream));
+    data_ptr = static_cast<void *>(ctx->wh->get_ptr());
+    dev_type = kDLCUDA;
+    dev_id = cuda_impl->get_device_id();
+  } else  // NOLINT(readability/braces)
+#endif
+  if (backend == "cpu") {
+    data_ptr = static_cast<void *>(msg.data.data());
+  } else {
+    throw std::runtime_error(
+            "torch_conversions::from_output_image_msg: unsupported backend " + backend);
+  }
+
+  auto * dlm = new DLManagedTensor;
+  populate_image_dl_tensor(*dlm, metadata, *ctx, data_ptr, dev_type, dev_id);
+  dlm->manager_ctx = ctx.release();
+  dlm->deleter = dlpack_deleter;
+  return dlm;
+}
+
 /// RAII wrapper for a DLManagedTensor. Useful when you're not immediately
 /// handing the tensor off to a framework's `from_dlpack` (which would take
 /// ownership itself). Calling `.release()` hands the raw pointer to such a
@@ -509,6 +704,157 @@ inline std::unique_ptr<TensorMsg> allocate_tensor_msg(
   throw std::runtime_error(
           "torch_conversions: unsupported device type " +
           std::to_string(static_cast<int>(dev)));
+}
+
+
+// ---------------------------------------------------------------------------
+// sensor_msgs/Image allocation and conversion
+// ---------------------------------------------------------------------------
+
+/// Allocate a packed HWC Image with a pre-sized data buffer. The metadata is
+/// initialized completely, and data uses CUDA storage when CUDA is selected.
+inline std::unique_ptr<ImageMsg> allocate_image_msg(
+  uint32_t height,
+  uint32_t width,
+  const std::string & encoding,
+  std::optional<c10::DeviceType> device = std::nullopt)
+{
+  if (encoding.empty() || sensor_msgs::image_encodings::isPlanar(encoding)) {
+    throw std::runtime_error(
+            "torch_conversions::allocate_image_msg: encoding must be a packed byte encoding");
+  }
+  int channels;
+  int bits;
+  try {
+    channels = sensor_msgs::image_encodings::numChannels(encoding);
+    bits = sensor_msgs::image_encodings::bitDepth(encoding);
+  } catch (const std::runtime_error & error) {
+    throw std::runtime_error(
+            std::string("torch_conversions::allocate_image_msg: ") + error.what());
+  }
+  if (channels <= 0 || bits != 8) {
+    throw std::runtime_error(
+            "torch_conversions::allocate_image_msg: only byte-oriented packed "
+            "encodings are supported");
+  }
+
+  const size_t step = detail::checked_multiply(
+    static_cast<size_t>(width), static_cast<size_t>(channels), "allocate_image_msg");
+  if (step > std::numeric_limits<uint32_t>::max()) {
+    throw std::runtime_error(
+            "torch_conversions::allocate_image_msg: packed row size exceeds Image.step");
+  }
+  const size_t byte_count = detail::checked_multiply(
+    static_cast<size_t>(height), step, "allocate_image_msg");
+
+  auto msg = std::make_unique<ImageMsg>();
+  msg->height = height;
+  msg->width = width;
+  msg->encoding = encoding;
+  msg->is_bigendian = 0;
+  msg->step = static_cast<uint32_t>(step);
+
+  const c10::DeviceType dev = device.value_or(detail::default_device());
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+  if (dev == c10::kCUDA) {
+    auto cuda_impl =
+      std::make_unique<cuda_buffer_backend::CudaBufferImpl<uint8_t>>(byte_count);
+    msg->data = rosidl::Buffer<uint8_t>(std::move(cuda_impl));
+    return msg;
+  }
+#endif
+  if (dev == c10::kCPU) {
+    msg->data.resize(byte_count);
+    return msg;
+  }
+  throw std::runtime_error(
+          "torch_conversions::allocate_image_msg: unsupported device type " +
+          std::to_string(static_cast<int>(dev)));
+}
+
+/// Return a writable HWC tensor view over Image.data. The CUDA WriteHandle
+/// remains alive until the returned tensor is destroyed.
+inline at::Tensor from_output_image_msg(ImageMsg & msg)
+{
+  if (msg.data.empty() && msg.height == 0 && msg.width == 0) {return {};}
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+  cudaStream_t stream = nullptr;
+  if (msg.data.get_backend_type() == "cuda") {
+    stream = detail::current_cuda_stream_or_warn("from_output_image_msg");
+  }
+  detail::DlpackPtr guard{detail::make_output_image_dlpack(msg, stream)};
+#else
+  detail::DlpackPtr guard{detail::make_output_image_dlpack(msg)};
+#endif
+  at::Tensor tensor = at::fromDLPack(guard.get());
+  (void)guard.release();
+  return tensor;
+}
+
+/// Return an HWC tensor for subscriber input. clone=false is a zero-copy,
+/// read-only view whose CUDA ReadHandle remains alive with the tensor.
+inline at::Tensor from_input_image_msg(const ImageMsg & msg, bool clone = true)
+{
+  if (msg.data.empty() && msg.height == 0 && msg.width == 0) {return {};}
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+  cudaStream_t stream = nullptr;
+  if (msg.data.get_backend_type() == "cuda") {
+    stream = detail::current_cuda_stream_or_warn("from_input_image_msg");
+  }
+  detail::DlpackPtr guard{detail::make_input_image_dlpack(msg, stream)};
+#else
+  detail::DlpackPtr guard{detail::make_input_image_dlpack(msg)};
+#endif
+  at::Tensor tensor = at::fromDLPack(guard.get());
+  (void)guard.release();
+  return clone ? tensor.clone() : tensor;
+}
+
+/// Copy an HWC tensor into an existing Image allocation. Existing header and
+/// image metadata are preserved; the tensor must match them exactly.
+inline void to_image_msg(ImageMsg & msg, const at::Tensor & tensor)
+{
+  if (!tensor.defined()) {
+    throw std::runtime_error("torch_conversions::to_image_msg: tensor is undefined");
+  }
+  const auto metadata = detail::image_metadata(msg, "to_image_msg");
+  if (tensor.dim() != 3 ||
+    !std::equal(tensor.sizes().begin(), tensor.sizes().end(), metadata.shape.begin()))
+  {
+    throw std::runtime_error(
+            "torch_conversions::to_image_msg: tensor shape must match Image HWC metadata");
+  }
+  if (tensor.scalar_type() != metadata.dtype) {
+    throw std::runtime_error(
+            "torch_conversions::to_image_msg: tensor dtype does not match Image encoding");
+  }
+  at::Tensor output = from_output_image_msg(msg);
+  // Keep CUDA work stream-ordered. The WriteHandle records the event when
+  // output leaves scope; no device or stream synchronization is performed here.
+  output.copy_(tensor, /*non_blocking=*/ true);
+}
+
+/// Allocate an Image matching an HWC tensor and copy the tensor into it.
+inline std::unique_ptr<ImageMsg> to_image_msg(
+  const at::Tensor & tensor, const std::string & encoding)
+{
+  if (!tensor.defined() || tensor.dim() != 3) {
+    throw std::runtime_error(
+            "torch_conversions::to_image_msg: tensor must be a defined HWC tensor");
+  }
+  if (tensor.size(0) < 0 || tensor.size(0) > std::numeric_limits<uint32_t>::max() ||
+    tensor.size(1) < 0 || tensor.size(1) > std::numeric_limits<uint32_t>::max())
+  {
+    throw std::runtime_error(
+            "torch_conversions::to_image_msg: tensor dimensions exceed Image metadata");
+  }
+  auto msg = allocate_image_msg(
+    static_cast<uint32_t>(tensor.size(0)),
+    static_cast<uint32_t>(tensor.size(1)),
+    encoding,
+    tensor.device().type());
+  to_image_msg(*msg, tensor);
+  return msg;
 }
 
 

--- a/torch_conversions/torch_conversions/package.xml
+++ b/torch_conversions/torch_conversions/package.xml
@@ -4,7 +4,7 @@
   <name>torch_conversions</name>
   <version>0.1.2</version>
   <description>Header-only helper library that converts between a
-  tensor_msgs/ExperimentalTensor message and an at::Tensor backed by rosidl::Buffer storage.</description>
+  tensor_msgs/ExperimentalTensor or sensor_msgs/Image message and an at::Tensor backed by rosidl::Buffer storage.</description>
 
   <maintainer email="yuankunz@nvidia.com">Yuankun Zhu</maintainer>
   <license>Apache-2.0</license>
@@ -16,11 +16,13 @@
   <depend>rcutils</depend>
   <depend>rmw</depend>
   <depend>rosidl_buffer</depend>
+  <depend>sensor_msgs</depend>
   <depend>tensor_msgs</depend>
 
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>launch_ros</test_depend>
   <test_depend>launch_testing_ament_cmake</test_depend>
   <test_depend>rclcpp</test_depend>
   <test_depend>rclcpp_components</test_depend>

--- a/torch_conversions/torch_conversions/test/test_torch_conversions.cpp
+++ b/torch_conversions/torch_conversions/test/test_torch_conversions.cpp
@@ -19,7 +19,16 @@
 
 #include "torch_conversions/torch_conversions.hpp"
 
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+#include <torch/cuda.h>
+#endif
+
 using torch_conversions::TensorMsg;
+using torch_conversions::ImageMsg;
+using torch_conversions::allocate_image_msg;
+using torch_conversions::from_input_image_msg;
+using torch_conversions::from_output_image_msg;
+using torch_conversions::to_image_msg;
 using torch_conversions::allocate_tensor_msg;
 using torch_conversions::from_input_tensor_msg;
 using torch_conversions::from_output_tensor_msg;
@@ -259,6 +268,147 @@ TEST(TorchTensorBridge, DlpackPtrFreesOnScopeExit)
   ASSERT_NE(raw, nullptr);
   raw->deleter(raw);  // caller takes over ownership
 }
+
+TEST(TorchImageBridge, AllocateCpuImageInitializesMetadataAndStorage)
+{
+  auto msg = allocate_image_msg(2, 3, "rgb8", c10::kCPU);
+
+  EXPECT_EQ(msg->height, 2u);
+  EXPECT_EQ(msg->width, 3u);
+  EXPECT_EQ(msg->encoding, "rgb8");
+  EXPECT_EQ(msg->is_bigendian, 0u);
+  EXPECT_EQ(msg->step, 9u);
+  EXPECT_EQ(msg->data.size(), 18u);
+  EXPECT_EQ(msg->data.get_backend_type(), "cpu");
+}
+
+TEST(TorchImageBridge, WritableAndReadOnlyViewsRoundTripAsHwc)
+{
+  auto msg = allocate_image_msg(2, 3, "rgb8", c10::kCPU);
+  {
+    at::Tensor output = from_output_image_msg(*msg);
+    EXPECT_EQ(output.sizes(), (std::vector<int64_t>{2, 3, 3}));
+    EXPECT_EQ(output.strides(), (std::vector<int64_t>{9, 3, 1}));
+    EXPECT_EQ(output.scalar_type(), at::kByte);
+    output.copy_(torch::arange(0, 18, at::kByte).reshape({2, 3, 3}));
+  }
+
+  at::Tensor view = from_input_image_msg(*msg, false);
+  EXPECT_EQ(view.data_ptr<uint8_t>(), msg->data.data());
+  EXPECT_TRUE(torch::equal(
+    view.flatten(), torch::arange(0, 18, at::kByte)));
+}
+
+TEST(TorchImageBridge, PaddedRowsProduceStridedHwcView)
+{
+  ImageMsg msg;
+  msg.height = 2;
+  msg.width = 2;
+  msg.encoding = "rgb8";
+  msg.step = 8;
+  msg.data.resize(16);
+
+  at::Tensor view = from_output_image_msg(msg);
+  EXPECT_EQ(view.sizes(), (std::vector<int64_t>{2, 2, 3}));
+  EXPECT_EQ(view.strides(), (std::vector<int64_t>{8, 3, 1}));
+  view.fill_(7);
+  EXPECT_EQ(msg.data[5], 7u);
+  EXPECT_EQ(msg.data[6], 0u);
+  EXPECT_EQ(msg.data[7], 0u);
+  EXPECT_EQ(msg.data[8], 7u);
+}
+
+TEST(TorchImageBridge, CopyPreservesImageMetadataAndHeader)
+{
+  auto msg = allocate_image_msg(2, 3, "rgb8", c10::kCPU);
+  msg->header.frame_id = "camera";
+  at::Tensor source = torch::arange(0, 18, at::kByte).reshape({2, 3, 3});
+
+  to_image_msg(*msg, source);
+
+  EXPECT_EQ(msg->header.frame_id, "camera");
+  EXPECT_EQ(msg->encoding, "rgb8");
+  EXPECT_EQ(msg->step, 9u);
+  EXPECT_TRUE(torch::equal(from_input_image_msg(*msg, false), source));
+}
+
+TEST(TorchImageBridge, AllocatingCopyDerivesDimensionsFromHwcTensor)
+{
+  at::Tensor source = torch::ones({4, 5, 3}, at::kByte);
+  auto msg = to_image_msg(source, "bgr8");
+
+  EXPECT_EQ(msg->height, 4u);
+  EXPECT_EQ(msg->width, 5u);
+  EXPECT_EQ(msg->step, 15u);
+  EXPECT_EQ(msg->encoding, "bgr8");
+  EXPECT_TRUE(torch::equal(from_input_image_msg(*msg, false), source));
+}
+
+TEST(TorchImageBridge, SignedByteEncodingProducesCharTensor)
+{
+  auto msg = allocate_image_msg(2, 3, "8SC1", c10::kCPU);
+  EXPECT_EQ(from_output_image_msg(*msg).scalar_type(), at::kChar);
+}
+
+TEST(TorchImageBridge, RejectsInvalidImageBoundsAndEncoding)
+{
+  ImageMsg short_step;
+  short_step.height = 2;
+  short_step.width = 3;
+  short_step.encoding = "rgb8";
+  short_step.step = 8;
+  short_step.data.resize(16);
+  EXPECT_THROW(from_input_image_msg(short_step, false), std::runtime_error);
+
+  ImageMsg short_data;
+  short_data.height = 2;
+  short_data.width = 3;
+  short_data.encoding = "rgb8";
+  short_data.step = 9;
+  short_data.data.resize(17);
+  EXPECT_THROW(from_input_image_msg(short_data, false), std::runtime_error);
+
+  EXPECT_THROW(allocate_image_msg(2, 3, "mono16", c10::kCPU), std::runtime_error);
+  EXPECT_THROW(allocate_image_msg(2, 3, "nv12", c10::kCPU), std::runtime_error);
+}
+
+TEST(TorchImageBridge, RejectsTensorShapeAndDtypeMismatch)
+{
+  auto msg = allocate_image_msg(2, 3, "rgb8", c10::kCPU);
+  EXPECT_THROW(to_image_msg(*msg, torch::zeros({2, 3}, at::kByte)), std::runtime_error);
+  EXPECT_THROW(to_image_msg(*msg, torch::zeros({2, 3, 3}, at::kFloat)), std::runtime_error);
+  EXPECT_THROW(to_image_msg(torch::zeros({2, 3}, at::kByte), "rgb8"), std::runtime_error);
+}
+
+#ifdef TORCH_CONVERSIONS_HAS_CUDA
+TEST(TorchImageBridge, CudaStorageViewsAndAsyncCopyRoundTrip)
+{
+  if (!torch::cuda::is_available()) {
+    GTEST_SKIP() << "CUDA is not available at runtime";
+  }
+
+  auto stream_guard = torch_conversions::set_stream();
+  auto msg = allocate_image_msg(2, 3, "rgb8", c10::kCUDA);
+  EXPECT_EQ(msg->data.get_backend_type(), "cuda");
+
+  at::Tensor output = from_output_image_msg(*msg);
+  EXPECT_TRUE(output.is_cuda());
+  output = {};  // Release the WriteHandle before acquiring subscriber input.
+
+  at::Tensor source = torch::arange(
+    0, 18, torch::TensorOptions().dtype(at::kByte).device(c10::kCUDA))
+    .reshape({2, 3, 3});
+  to_image_msg(*msg, source);
+
+  at::Tensor input = from_input_image_msg(*msg, false);
+  EXPECT_TRUE(input.is_cuda());
+  EXPECT_EQ(input.sizes(), (std::vector<int64_t>{2, 3, 3}));
+
+  // Synchronization belongs to the materializing test/sink, not conversions.
+  torch::cuda::synchronize();
+  EXPECT_TRUE(torch::equal(input.cpu(), source.cpu()));
+}
+#endif
 
 int main(int argc, char ** argv)
 {


### PR DESCRIPTION
## Description

  Add native `sensor_msgs/msg/Image` support to `torch_conversions` library.

  This change introduces APIs to:

  - Allocate initialized CPU- or CUDA-backed image messages.
  - Create writable HWC tensor views over image buffers.
  - Create cloned or zero-copy HWC tensor views from received images.
  - Copy tensors into existing image messages while preserving headers and image metadata.
  - Allocate and populate image messages directly from HWC tensors.
  - Preserve row padding through tensor strides.

  The conversion path maintains CUDA buffer lifetime and stream-event ordering without introducing device or stream synchronization. It supports packed, byte-oriented encodings and validates encodings,
  buffer sizes, row strides, tensor shapes, and data types.

  ### Is this user-facing behavior change?

  Yes. Users can now convert native ROS `sensor_msgs/msg/Image` messages directly to and from PyTorch `at::Tensor` objects.

  Images are represented as HWC tensors. Zero-copy input views are available by passing `clone=false`.

  ### Did you use Generative AI?

  OpenAI Codex (GPT-5) was used to draft the changes in this pull request.

  ### Additional Information

  The current implementation supports packed, 8-bit-per-channel encodings, including `mono8`, `rgb8`, `bgr8`, `rgba8`, Bayer8, YUV422, and `8UC`/`8SC` encodings. Planar and non-byte encodings are rejected
  with descriptive errors.

  For zero-copy CPU input views, the source message must remain alive while the tensor is in use. CUDA views retain the appropriate buffer handles and stream-event dependencies for the tensor lifetime.


