### PR TITLE
Avoid same-process CUDA publish synchronization

### DIFF
--- a/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_memory_pool.hpp
+++ b/cuda_buffer_backend/cuda_buffer/include/cuda_buffer/cuda_memory_pool.hpp
@@ -51,6 +51,7 @@ struct VmmBlock
   size_t size{0};
   int exported_fd{-1};
   uint32_t block_id{0};
+  cudaEvent_t local_event{nullptr};
 
   IPCMetadata * ipc_meta{nullptr};
   int shm_fd{-1};

--- a/cuda_buffer_backend/cuda_buffer/src/cuda_memory_pool.cpp
+++ b/cuda_buffer_backend/cuda_buffer/src/cuda_memory_pool.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "cuda_buffer/cuda_memory_pool.hpp"
+#include "cuda_buffer/cuda_buffer_handle.hpp"
 
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -50,6 +51,10 @@ CudaMemoryPool::~CudaMemoryPool()
 
   std::lock_guard<std::mutex> lock(mutex_);
   for (auto & block : all_blocks_) {
+    if (block->local_event) {
+      CUDA_CHECK_NOTHROW(cudaEventDestroy(block->local_event), (void)0);
+      block->local_event = nullptr;
+    }
     if (block->ipc_meta) {
       munmap(block->ipc_meta, sizeof(IPCMetadata));
       block->ipc_meta = nullptr;
@@ -247,6 +252,18 @@ VmmBlock * CudaMemoryPool::create_block(size_t aligned_size)
   }
 
   if (ipc_capable_) {
+    cudaError_t event_error = cudaEventCreateWithFlags(
+      &block->local_event, CUDA_BUFFER_MINIMUM_EVENT_FLAGS);
+    if (event_error != cudaSuccess) {
+      RCUTILS_LOG_WARN_ONCE_NAMED(
+        "cuda_memory_pool",
+        "Failed to create a same-process CUDA synchronization event: %s (%s); "
+        "same-process transport will synchronize the publish path",
+        cudaGetErrorName(event_error), cudaGetErrorString(event_error));
+      block->local_event = nullptr;
+      (void)cudaGetLastError();
+    }
+
     int fd = -1;
     r = cuMemExportToShareableHandle(
       &fd, block->handle, CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR, 0);

--- a/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
+++ b/cuda_buffer_backend/cuda_buffer_backend/CMakeLists.txt
@@ -119,6 +119,21 @@ if(BUILD_TESTING)
   rclcpp_components_register_nodes(cuda_image_dso_publisher_component
     "CudaImageDsoPublisher")
 
+  ament_auto_add_library(cuda_image_intra_process_event_publisher_component SHARED
+    test/src/cuda_image_intra_process_event_publisher_node.cpp
+  )
+  target_link_libraries(cuda_image_intra_process_event_publisher_component
+    cuda_buffer::cuda_buffer
+    CUDA::cudart
+    rclcpp::rclcpp
+    rclcpp_components::component
+    ${sensor_msgs_TARGETS}
+    ${std_msgs_TARGETS}
+    rosidl_runtime_cpp::rosidl_runtime_cpp
+  )
+  rclcpp_components_register_nodes(cuda_image_intra_process_event_publisher_component
+    "CudaImageIntraProcessEventPublisher")
+
   ament_auto_add_library(cuda_image_subscriber_component SHARED
     test/src/cuda_image_subscriber_node.cpp
   )
@@ -157,6 +172,11 @@ if(BUILD_TESTING)
   add_launch_test(test/test_cuda_image_intra_pubsub_fastrtps_launch.py
     TARGET test_cuda_image_intra_pubsub_fastrtps_launch
     TIMEOUT 30
+  )
+
+  add_launch_test(test/test_cuda_image_intra_process_event_fastrtps_launch.py
+    TARGET test_cuda_image_intra_process_event_fastrtps_launch
+    TIMEOUT 45
   )
 
   add_launch_test(test/test_cuda_image_mixed_pubsub_fastrtps_launch.py

--- a/cuda_buffer_backend/cuda_buffer_backend/src/cuda_buffer_backend_plugin.cpp
+++ b/cuda_buffer_backend/cuda_buffer_backend/src/cuda_buffer_backend_plugin.cpp
@@ -187,27 +187,40 @@ std::shared_ptr<void> CudaBufferBackend::create_descriptor_with_endpoint(
 
   cudaEvent_t write_event = cuda_impl->get_cuda_buffer().get_write_event();
 
+  descriptor->event_type = cuda_buffer_backend_msgs::msg::CudaBufferDescriptor::EVENT_NONE;
+  std::memset(descriptor->ipc_event_handle.data(), 0, descriptor->ipc_event_handle.size());
+
   rmw_gid_t gid;
   gid.implementation_identifier = "";
   std::memcpy(gid.data, endpoint_info.endpoint_gid, RMW_GID_STORAGE_SIZE);
   auto locality = get_endpoint_manager()->query_endpoint_locality(gid);
-  if (locality.found &&
-    locality.locality == host_endpoint_manager::EndpointLocality::INTRA_PROCESS &&
-    write_event)
-  {
-    RCUTILS_LOG_WARN_ONCE_NAMED("cuda_buffer_backend",
-      "Same-process CUDA IPC requires cudaEventSynchronize on the publish path. "
-      "Enable intra-process communication to avoid this overhead.");
-    cudaEventSynchronize(write_event);
-  }
+  const bool is_same_process = locality.found &&
+    locality.locality == host_endpoint_manager::EndpointLocality::INTRA_PROCESS;
 
   if (write_event) {
-    cudaIpcEventHandle_t event_handle;
-    CUDA_CHECK(cudaIpcGetEventHandle(&event_handle, write_event));
-    std::memcpy(
-      descriptor->ipc_event_handle.data(), &event_handle, sizeof(cudaIpcEventHandle_t));
-  } else {
-    std::memset(descriptor->ipc_event_handle.data(), 0, sizeof(cudaIpcEventHandle_t));
+    if (is_same_process && block->local_event) {
+      cudaStream_t stream = get_internal_stream();
+      CUDA_CHECK(cudaStreamWaitEvent(stream, write_event, 0));
+      CUDA_CHECK(cudaEventRecord(block->local_event, stream));
+
+      static_assert(sizeof(cudaEvent_t) <= sizeof(cudaIpcEventHandle_t));
+      descriptor->event_type =
+        cuda_buffer_backend_msgs::msg::CudaBufferDescriptor::EVENT_LOCAL;
+      std::memcpy(
+        descriptor->ipc_event_handle.data(), &block->local_event, sizeof(cudaEvent_t));
+    } else if (is_same_process) {
+      RCUTILS_LOG_WARN_ONCE_NAMED(
+        "cuda_buffer_backend",
+        "No local CUDA synchronization event is available; synchronizing the publish path");
+      CUDA_CHECK(cudaEventSynchronize(write_event));
+    } else {
+      cudaIpcEventHandle_t event_handle;
+      CUDA_CHECK(cudaIpcGetEventHandle(&event_handle, write_event));
+      descriptor->event_type =
+        cuda_buffer_backend_msgs::msg::CudaBufferDescriptor::EVENT_IPC;
+      std::memcpy(
+        descriptor->ipc_event_handle.data(), &event_handle, sizeof(cudaIpcEventHandle_t));
+    }
   }
 
   return descriptor;
@@ -257,28 +270,34 @@ std::unique_ptr<void, void (*)(void *)> CudaBufferBackend::from_descriptor_with_
         reinterpret_cast<void *>(import_result.va), byte_size,
         descriptor->device_id, deleter);
 
-      bool has_event = false;
-      for (size_t i = 0; i < descriptor->ipc_event_handle.size(); ++i) {
-        if (descriptor->ipc_event_handle[i] != 0) {
-          has_event = true;
+      switch (descriptor->event_type) {
+        case cuda_buffer_backend_msgs::msg::CudaBufferDescriptor::EVENT_LOCAL:
+          {
+            cudaEvent_t local_event = nullptr;
+            std::memcpy(
+              &local_event, descriptor->ipc_event_handle.data(), sizeof(cudaEvent_t));
+            if (local_event) {
+              imported_buffer.set_write_event(local_event, false);
+            }
+          }
           break;
-        }
-      }
+        case cuda_buffer_backend_msgs::msg::CudaBufferDescriptor::EVENT_IPC:
+          {
+            cudaIpcEventHandle_t event_handle;
+            std::memcpy(&event_handle, descriptor->ipc_event_handle.data(),
+                sizeof(cudaIpcEventHandle_t));
 
-      if (has_event) {
-        cudaIpcEventHandle_t event_handle;
-        std::memcpy(&event_handle, descriptor->ipc_event_handle.data(),
-            sizeof(cudaIpcEventHandle_t));
-
-        cudaEvent_t imported_event = nullptr;
-        cudaError_t ev_err = cudaIpcOpenEventHandle(&imported_event, event_handle);
-        if (ev_err == cudaSuccess) {
-          imported_buffer.set_write_event(imported_event, true);
-        } else {
-          // Same-process: IPC event handles can't be opened in the originating
-          // process.
-          (void)cudaGetLastError();
-        }
+            cudaEvent_t imported_event = nullptr;
+            CUDA_CHECK(cudaIpcOpenEventHandle(&imported_event, event_handle));
+            imported_buffer.set_write_event(imported_event, true);
+          }
+          break;
+        case cuda_buffer_backend_msgs::msg::CudaBufferDescriptor::EVENT_NONE:
+          break;
+        default:
+          throw CudaError(
+                "CudaBufferDescriptor contains an unknown CUDA event type: " +
+                std::to_string(descriptor->event_type));
       }
 
       auto result = std::make_unique<CudaBufferImpl<uint8_t>>(

--- a/cuda_buffer_backend/cuda_buffer_backend/test/src/cuda_image_intra_process_event_publisher_node.cpp
+++ b/cuda_buffer_backend/cuda_buffer_backend/test/src/cuda_image_intra_process_event_publisher_node.cpp
@@ -1,0 +1,132 @@
+// Copyright 2026 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_runtime.h>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <thread>
+
+#include "cuda_buffer/cuda_buffer_api.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "rclcpp_components/register_node_macro.hpp"
+#include "sensor_msgs/msg/image.hpp"
+#include "std_msgs/msg/bool.hpp"
+
+class CudaImageIntraProcessEventPublisher : public rclcpp::Node
+{
+public:
+  explicit CudaImageIntraProcessEventPublisher(const rclcpp::NodeOptions & options)
+  : Node("cuda_image_intra_process_event_publisher", options)
+  {
+    CUDA_CHECK(cudaStreamCreateWithFlags(&stream_, cudaStreamNonBlocking));
+    CUDA_CHECK(cudaEventCreateWithFlags(
+      &completion_event_, cudaEventDisableTiming));
+    publisher_ = create_publisher<sensor_msgs::msg::Image>("test_cuda_image_intra_event", 10);
+    nonblocking_publisher_ =
+      create_publisher<std_msgs::msg::Bool>("intra_event_publish_nonblocking", 10);
+    timer_ = create_wall_timer(
+      std::chrono::milliseconds(100),
+      std::bind(&CudaImageIntraProcessEventPublisher::publish_next, this));
+  }
+
+  ~CudaImageIntraProcessEventPublisher() override
+  {
+    if (stream_ != nullptr) {
+      (void)cudaStreamSynchronize(stream_);
+      (void)cudaEventDestroy(completion_event_);
+      completion_event_ = nullptr;
+      (void)cudaStreamDestroy(stream_);
+    }
+  }
+
+private:
+  static constexpr std::size_t kMessages = 5;
+  static constexpr std::size_t kPayloadSize = 4096;
+  static constexpr auto kStreamDelay = std::chrono::milliseconds(250);
+
+  static std::uint8_t pattern_for(std::size_t sequence)
+  {
+    return static_cast<std::uint8_t>((sequence * 37u + 11u) & 0xffu);
+  }
+
+  static void stream_delay(void * user_data)
+  {
+    static_cast<void>(user_data);
+    std::this_thread::sleep_for(kStreamDelay);
+  }
+
+  void publish_next()
+  {
+    if (sequence_ >= kMessages) {
+      timer_->cancel();
+      return;
+    }
+    if (publisher_->get_subscription_count() == 0u ||
+      nonblocking_publisher_->get_subscription_count() == 0u)
+    {
+      return;
+    }
+
+    const std::size_t sequence = sequence_ + 1u;
+    const std::uint8_t pattern = pattern_for(sequence);
+
+    sensor_msgs::msg::Image msg;
+    msg.header.stamp = now();
+    msg.header.frame_id = "cuda_pool_dso_" + std::to_string(sequence);
+    msg.height = 16;
+    msg.width = 256;
+    msg.encoding = "mono8";
+    msg.is_bigendian = 0;
+    msg.step = 256;
+    msg.data = cuda_buffer_backend::allocate_buffer(kPayloadSize);
+
+    {
+      CUDA_CHECK(cudaLaunchHostFunc(stream_, stream_delay, nullptr));
+      auto write_handle = cuda_buffer_backend::from_output_buffer(msg.data, stream_);
+      CUDA_CHECK(cudaMemsetAsync(write_handle.get_ptr(), pattern, kPayloadSize, stream_));
+      CUDA_CHECK(cudaEventRecord(completion_event_, stream_));
+    }
+
+    publisher_->publish(msg);
+    cudaError_t completion_status = cudaEventQuery(completion_event_);
+    const bool publish_was_nonblocking = completion_status == cudaErrorNotReady;
+    if (publish_was_nonblocking) {
+      (void)cudaGetLastError();
+    } else {
+      CUDA_CHECK(completion_status);
+    }
+
+    std_msgs::msg::Bool nonblocking_msg;
+    nonblocking_msg.data = publish_was_nonblocking;
+    nonblocking_publisher_->publish(nonblocking_msg);
+    sequence_ = sequence;
+    RCLCPP_INFO(
+      get_logger(), "INTRA_EVENT_PUBLISH_RESULT message=%zu backend=%s pattern=%u nonblocking=%s",
+      sequence_, msg.data.get_backend_type().c_str(), static_cast<unsigned>(pattern),
+      publish_was_nonblocking ? "true" : "false");
+  }
+
+  rclcpp::Publisher<sensor_msgs::msg::Image>::SharedPtr publisher_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr nonblocking_publisher_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  cudaStream_t stream_{nullptr};
+  cudaEvent_t completion_event_{nullptr};
+  std::size_t sequence_{0};
+};
+
+RCLCPP_COMPONENTS_REGISTER_NODE(CudaImageIntraProcessEventPublisher)

--- a/cuda_buffer_backend/cuda_buffer_backend/test/test_cuda_image_intra_process_event_fastrtps_launch.py
+++ b/cuda_buffer_backend/cuda_buffer_backend/test/test_cuda_image_intra_process_event_fastrtps_launch.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+# Copyright 2026 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+import unittest
+
+from launch import LaunchDescription
+from launch.actions import SetEnvironmentVariable
+from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import LoadComposableNodes
+from launch_ros.descriptions import ComposableNode
+import launch_testing
+import launch_testing.actions
+import launch_testing.asserts
+import launch_testing.markers
+from launch_testing_ros.actions import EnableRmwIsolation
+import pytest
+import rclpy
+from std_msgs.msg import Bool, UInt32
+
+
+@pytest.mark.launch_test
+@launch_testing.markers.keep_alive
+def generate_test_description():
+    """Generate a deterministic same-process CUDA event regression test."""
+    test_domain_id = str(100 + os.getpid() % 100)
+
+    publisher_container = ComposableNodeContainer(
+        name='cuda_image_intra_event_publisher_container',
+        namespace='',
+        package='rclcpp_components',
+        executable='component_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='cuda_buffer_backend',
+                plugin='CudaImageIntraProcessEventPublisher',
+                extra_arguments=[{'use_intra_process_comms': False}],
+                name='cuda_image_intra_event_publisher',
+            ),
+        ],
+        output='screen',
+    )
+
+    subscriber_loader = LoadComposableNodes(
+        target_container='/cuda_image_intra_event_publisher_container',
+        composable_node_descriptions=[
+            ComposableNode(
+                package='cuda_buffer_backend',
+                plugin='CudaImageSubscriber',
+                extra_arguments=[{'use_intra_process_comms': False}],
+                name='cuda_image_intra_event_subscriber',
+                parameters=[{
+                    'expected_backend': 'cuda',
+                    'acceptable_buffer_backends': 'cuda',
+                    'validate_sequence_pattern': True,
+                }],
+                remappings=[
+                    ('test_cuda_image', 'test_cuda_image_intra_event'),
+                    ('subscriber_count', 'cuda_image_intra_event_subscriber_count'),
+                    ('validation_result', 'cuda_image_intra_event_validation'),
+                    ('backend_validation', 'cuda_image_intra_event_backend_validation'),
+                    ('content_validation', 'cuda_image_intra_event_content_validation'),
+                    ('metadata_validation', 'cuda_image_intra_event_metadata_validation'),
+                ],
+            ),
+        ],
+    )
+
+    return LaunchDescription([
+        SetEnvironmentVariable('RMW_IMPLEMENTATION', 'rmw_fastrtps_cpp'),
+        SetEnvironmentVariable('ROS_DOMAIN_ID', test_domain_id),
+        EnableRmwIsolation(),
+        publisher_container,
+        subscriber_loader,
+        launch_testing.actions.ReadyToTest(),
+    ])
+
+
+class TestCudaImageIntraProcessEventFastRTPS(unittest.TestCase):
+    """Verify CUDA descriptor transport without publish-side CUDA synchronization."""
+
+    @classmethod
+    def setUpClass(cls):
+        rclpy.init()
+
+    @classmethod
+    def tearDownClass(cls):
+        rclpy.shutdown()
+
+    def setUp(self):
+        self.node = rclpy.create_node('test_cuda_image_intra_event_fastrtps')
+        self.received_count = 0
+        self.validation_count = 0
+        self.backend_validation_count = 0
+        self.content_validation_count = 0
+        self.metadata_validation_count = 0
+        self.nonblocking_validation_count = 0
+        self.all_valid = True
+
+        self.node.create_subscription(
+            UInt32, 'cuda_image_intra_event_subscriber_count', self._count_cb, 10)
+        self.node.create_subscription(
+            Bool, 'cuda_image_intra_event_validation', self._validation_cb, 10)
+        self.node.create_subscription(
+            Bool, 'cuda_image_intra_event_backend_validation', self._backend_cb, 10)
+        self.node.create_subscription(
+            Bool, 'cuda_image_intra_event_content_validation', self._content_cb, 10)
+        self.node.create_subscription(
+            Bool, 'cuda_image_intra_event_metadata_validation', self._metadata_cb, 10)
+        self.node.create_subscription(
+            Bool, 'intra_event_publish_nonblocking', self._nonblocking_cb, 10)
+
+    def tearDown(self):
+        self.node.destroy_node()
+
+    def _count_cb(self, msg):
+        self.received_count = msg.data
+
+    def _validation_cb(self, msg):
+        self.validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _backend_cb(self, msg):
+        self.backend_validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _content_cb(self, msg):
+        self.content_validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _metadata_cb(self, msg):
+        self.metadata_validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _nonblocking_cb(self, msg):
+        self.nonblocking_validation_count += 1
+        self.all_valid = self.all_valid and msg.data
+
+    def _complete(self):
+        return (
+            self.received_count >= 5 and
+            self.validation_count >= 5 and
+            self.backend_validation_count >= 5 and
+            self.content_validation_count >= 5 and
+            self.metadata_validation_count >= 5 and
+            self.nonblocking_validation_count >= 5
+        )
+
+    def test_five_cuda_messages_validate(self):
+        """Require an explicit successful validation for every CUDA message."""
+        deadline = time.monotonic() + 30.0
+        while not self._complete() and time.monotonic() < deadline:
+            rclpy.spin_once(self.node, timeout_sec=0.1)
+
+        self.assertTrue(
+            self._complete(),
+            'Did not observe five complete validations: '
+            f'received={self.received_count}, validation={self.validation_count}, '
+            f'backend={self.backend_validation_count}, '
+            f'content={self.content_validation_count}, '
+            f'metadata={self.metadata_validation_count}, '
+            f'nonblocking={self.nonblocking_validation_count}',
+        )
+        self.assertTrue(self.all_valid, 'At least one CUDA same-process event validation failed')
+
+
+@launch_testing.post_shutdown_test()
+class TestCudaImageIntraProcessEventFastRTPSShutdown(unittest.TestCase):
+    """Check that the component container shut down cleanly."""
+
+    def test_exit_codes(self, proc_info):
+        launch_testing.asserts.assertExitCodes(
+            proc_info,
+            allowable_exit_codes=[0, -2, -15],
+        )

--- a/cuda_buffer_backend/cuda_buffer_backend_msgs/msg/CudaBufferDescriptor.msg
+++ b/cuda_buffer_backend/cuda_buffer_backend_msgs/msg/CudaBufferDescriptor.msg
@@ -24,5 +24,10 @@ uint64 vmm_block_size          # Block size (for import mapping)
 string vmm_socket_path         # Unix socket path to receive block FD
 uint64 ipc_uid                 # Unique ID per publish for staleness detection
 
-# CUDA IPC event for inter-process GPU synchronization
-uint8[64] ipc_event_handle     # cudaIpcEventHandle_t (64 bytes)
+# CUDA event for GPU synchronization. Same-process descriptors carry a raw
+# cudaEvent_t; inter-process descriptors carry a cudaIpcEventHandle_t.
+uint8 EVENT_NONE=0
+uint8 EVENT_LOCAL=1
+uint8 EVENT_IPC=2
+uint8 event_type
+uint8[64] ipc_event_handle


### PR DESCRIPTION
 ## Description
                                                   
  This PR removes an unnecessary publish-path synchronization when CUDA-backed messages are transported between nodes in the same process through the regular DDS path.
                                                                                                      
  Previously, the CUDA serialization backend attempted to use a CUDA IPC event for every descriptor. CUDA IPC event handles cannot be reopened in the process that created them, so same-process descriptor
  transport called `cudaEventSynchronize()` before publishing. This preserved correctness but blocked the publisher until all queued CUDA work completed.

  ## Same-process event transport

  The CUDA allocation pool now owns a local CUDA event for each IPC-capable VMM block.

  When serializing a descriptor for a same-process endpoint, the backend:

  - Waits for the producer’s write event on an internal CUDA stream.
  - Records the pool-owned local event after that wait.
  - Stores the local `cudaEvent_t` in the descriptor.
  - Returns from publication without waiting for the GPU work to finish.

  The receiving backend attaches this event to the imported CUDA buffer as a non-owning write event. A subsequent `ReadHandle` waits for it on the consumer stream, preserving stream ordering without
  blocking the publisher thread.

  If a local event cannot be created, the backend retains the previous `cudaEventSynchronize()` behavior as a correctness-preserving fallback.

  ## Descriptor event types

  `CudaBufferDescriptor` now explicitly identifies how its event data should be interpreted:

  - `EVENT_NONE` — no producer event is attached.
  - `EVENT_LOCAL` — the descriptor contains a same-process `cudaEvent_t`.
  - `EVENT_IPC` — the descriptor contains an inter-process `cudaIpcEventHandle_t`.

  This avoids relying on PID comparisons, which can be incorrect across container PID namespaces.

  Inter-process transport continues to use CUDA IPC events. Imported IPC events remain receiver-owned, while same-process local events remain owned by the publisher’s allocation pool.

  ## Regression testing                          
                                                                                                      
  This PR adds a dedicated Fast RTPS launch test for same-process descriptor transport.

  The test:                                                                                           

  - Loads a dedicated CUDA publisher component and subscriber into the same process.                                                                                                                        
  - Disables ROS intra-process communication so the message uses the regular DDS serialization path.  
  - Queues delayed asynchronous CUDA work before each publication.
  - Publishes five CUDA-backed messages with distinct known payloads.                                 
  - Verifies that every `publish()` returns before the queued CUDA work completes.     
  - Checks the received backend before constructing a `ReadHandle`.                                   
  - Requires every received message to remain CUDA-backed.  
  - Materializes the data only for final validation and checks every payload.              
  - Requires explicit backend, content, metadata, and nonblocking validation results for all five messages.                                                                                                 
                                                                                                                                                                                                            
  Before the fix, the regression test receives valid CUDA payloads but fails because every publication reports `nonblocking=false`.                                                                         
                                                                                                      
  After the fix, all five publications report `nonblocking=true`, and all received CUDA payloads validate successfully.                                                                                     
    